### PR TITLE
Clean up human thinking indicator logic and update known issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,9 @@ git push origin ejfn/add-new-feature -u
 gh pr create --title "Your PR title" --body "Description"
 ```
 
+### Git Workflow Notes
+- Do not commit directly into main branch
+
 ### EAS CLI
 
 EAS CLI is a project dependency. Always use `npx`:

--- a/src/components/HumanPlayerView.tsx
+++ b/src/components/HumanPlayerView.tsx
@@ -25,7 +25,6 @@ interface HumanPlayerViewProps {
   trumpDeclarationMode?: boolean;
   onSkipTrumpDeclaration?: () => void;
   onConfirmTrumpDeclaration?: () => void;
-  isTransitioningTricks?: boolean;
 }
 
 /**
@@ -46,8 +45,7 @@ const HumanPlayerView: React.FC<HumanPlayerViewProps> = ({
   thinkingDots,
   trumpDeclarationMode = false,
   onSkipTrumpDeclaration,
-  onConfirmTrumpDeclaration,
-  isTransitioningTricks = false
+  onConfirmTrumpDeclaration
 }) => {
   return (
     <View style={styles.container}>
@@ -56,7 +54,7 @@ const HumanPlayerView: React.FC<HumanPlayerViewProps> = ({
         isDefending ? sharedStyles.teamALabel : sharedStyles.teamBLabel
       ]}>
         <Text style={sharedStyles.playerLabel}>You</Text>
-        {isCurrentPlayer && !showTrickResult && !lastCompletedTrick && !isTransitioningTricks && (
+        {isCurrentPlayer && !showTrickResult && !lastCompletedTrick && (
           <ThinkingIndicator
             visible={true}
             dots={thinkingDots}

--- a/src/screens/GameScreenView.tsx
+++ b/src/screens/GameScreenView.tsx
@@ -243,7 +243,6 @@ const GameScreenView: React.FC<GameScreenViewProps> = ({
                   showTrickResult={showTrickResult}
                   lastCompletedTrick={lastCompletedTrick}
                   thinkingDots={thinkingDots}
-                  isTransitioningTricks={isTransitioningTricks}
                   trumpDeclarationMode={showTrumpDeclaration}
                   onSkipTrumpDeclaration={() => onDeclareTrumpSuit(null)}
                   onConfirmTrumpDeclaration={onConfirmTrumpDeclaration}


### PR DESCRIPTION
## Summary
- Simplified human thinking indicator logic by removing unnecessary props and conditions
- Documented the timing issue as a known issue for future investigation
- Updated KNOWN_ISSUES.md to remove resolved issues and add new ones

## Changes

### Code Simplification
- Removed unnecessary props: `waitingForAI`, `isTransitioningTricks`, `currentTrick`
- Returned to simpler implementation with basic checks
- Known timing issue remains (brief flash when human wins trick)

### Documentation Updates
- Removed resolved issues:
  - Bot 1 not playing after human player
  - Card animation flicker
- Added new known issues:
  - Card strength rules not correctly implemented
  - Bot intelligence lacks strategic play
- Documented human thinking indicator flash with technical details

## Known Issues
- Human thinking indicator briefly flashes when human wins a trick
- This is a timing issue between state updates that remains unresolved
- Documented in KNOWN_ISSUES.md for future investigation

## Test plan
- [x] Code compiles without errors
- [x] Thinking indicator still functions correctly
- [x] Documentation accurately reflects current state

🤖 Generated with [Claude Code](https://claude.ai/code)