### PR TITLE
Implement advanced scoring rules and document game rule issues

### DIFF
--- a/__tests__/game-logic/advancedScoring.test.ts
+++ b/__tests__/game-logic/advancedScoring.test.ts
@@ -1,0 +1,353 @@
+import { endRound } from '../../src/utils/gameRoundManager';
+import { GameState, Team, Player, Rank } from '../../src/types/game';
+
+describe('Advanced Scoring Rules', () => {
+  const createMockGameState = (
+    defendingTeam: Team,
+    attackingTeam: Team
+  ): GameState => ({
+    teams: [defendingTeam, attackingTeam],
+    players: [] as Player[],
+    deck: [],
+    trumpInfo: {
+      trumpRank: Rank.Two,
+      trumpSuit: undefined,
+      declared: false
+    },
+    currentPlayerIndex: 0,
+    currentTrick: null,
+    gamePhase: 'playing',
+    tricks: [],
+    roundNumber: 1,
+    kittyCards: []
+  });
+
+  describe('Defending Team Successfully Defends', () => {
+    it('should advance defending team by 1 rank when attackers get 40-79 points', () => {
+      const defendingTeam: Team = {
+        id: 'A',
+        players: [],
+        isDefending: true,
+        currentRank: Rank.Three,
+        points: 0
+      };
+      const attackingTeam: Team = {
+        id: 'B',
+        players: [],
+        isDefending: false,
+        currentRank: Rank.Five,
+        points: 65
+      };
+
+      const gameState = createMockGameState(defendingTeam, attackingTeam);
+      const result = endRound(gameState);
+
+      expect(result.newState.teams[0].currentRank).toBe(Rank.Four);
+      expect(result.newState.teams[0].isDefending).toBe(true);
+      expect(result.roundCompleteMessage).toContain('65/80 points');
+      expect(result.roundCompleteMessage).toContain('advances 1 rank to 4');
+    });
+
+    it('should advance defending team by 2 ranks when attackers get < 40 points', () => {
+      const defendingTeam: Team = {
+        id: 'A',
+        players: [],
+        isDefending: true,
+        currentRank: Rank.Three,
+        points: 0
+      };
+      const attackingTeam: Team = {
+        id: 'B',
+        players: [],
+        isDefending: false,
+        currentRank: Rank.Five,
+        points: 25
+      };
+
+      const gameState = createMockGameState(defendingTeam, attackingTeam);
+      const result = endRound(gameState);
+
+      expect(result.newState.teams[0].currentRank).toBe(Rank.Five);
+      expect(result.newState.teams[0].isDefending).toBe(true);
+      expect(result.roundCompleteMessage).toContain('held attackers to only 25 points');
+      expect(result.roundCompleteMessage).toContain('advances 2 ranks to 5');
+    });
+
+    it('should advance defending team by 3 ranks when attackers get 0 points', () => {
+      const defendingTeam: Team = {
+        id: 'A',
+        players: [],
+        isDefending: true,
+        currentRank: Rank.Three,
+        points: 0
+      };
+      const attackingTeam: Team = {
+        id: 'B',
+        players: [],
+        isDefending: false,
+        currentRank: Rank.Five,
+        points: 0
+      };
+
+      const gameState = createMockGameState(defendingTeam, attackingTeam);
+      const result = endRound(gameState);
+
+      expect(result.newState.teams[0].currentRank).toBe(Rank.Six);
+      expect(result.newState.teams[0].isDefending).toBe(true);
+      expect(result.roundCompleteMessage).toContain('shut out the attackers');
+      expect(result.roundCompleteMessage).toContain('advances 3 ranks to 6');
+    });
+
+    it('should win the game when defending team reaches Ace', () => {
+      const defendingTeam: Team = {
+        id: 'A',
+        players: [],
+        isDefending: true,
+        currentRank: Rank.King,
+        points: 0
+      };
+      const attackingTeam: Team = {
+        id: 'B',
+        players: [],
+        isDefending: false,
+        currentRank: Rank.Five,
+        points: 0
+      };
+
+      const gameState = createMockGameState(defendingTeam, attackingTeam);
+      const result = endRound(gameState);
+
+      expect(result.gameOver).toBe(true);
+      expect(result.winner).toBe('A');
+    });
+  });
+
+  describe('Attacking Team Wins', () => {
+    it('should switch roles without rank advancement when attackers get 80-119 points', () => {
+      const defendingTeam: Team = {
+        id: 'A',
+        players: [],
+        isDefending: true,
+        currentRank: Rank.Three,
+        points: 0
+      };
+      const attackingTeam: Team = {
+        id: 'B',
+        players: [],
+        isDefending: false,
+        currentRank: Rank.Five,
+        points: 100
+      };
+
+      const gameState = createMockGameState(defendingTeam, attackingTeam);
+      const result = endRound(gameState);
+
+      expect(result.newState.teams[1].currentRank).toBe(Rank.Five); // No rank change
+      expect(result.newState.teams[1].isDefending).toBe(true); // Now defending
+      expect(result.newState.teams[0].isDefending).toBe(false); // Now attacking
+      expect(result.roundCompleteMessage).toContain('won with 100 points');
+      expect(result.roundCompleteMessage).toContain('will defend at rank 5');
+    });
+
+    it('should advance attacking team by 1 rank when they get 120-159 points', () => {
+      const defendingTeam: Team = {
+        id: 'A',
+        players: [],
+        isDefending: true,
+        currentRank: Rank.Three,
+        points: 0
+      };
+      const attackingTeam: Team = {
+        id: 'B',
+        players: [],
+        isDefending: false,
+        currentRank: Rank.Five,
+        points: 140
+      };
+
+      const gameState = createMockGameState(defendingTeam, attackingTeam);
+      const result = endRound(gameState);
+
+      expect(result.newState.teams[1].currentRank).toBe(Rank.Six);
+      expect(result.newState.teams[1].isDefending).toBe(true);
+      expect(result.roundCompleteMessage).toContain('won with 140 points');
+      expect(result.roundCompleteMessage).toContain('advances 1 rank to 6');
+    });
+
+    it('should advance attacking team by 2 ranks when they get 160-199 points', () => {
+      const defendingTeam: Team = {
+        id: 'A',
+        players: [],
+        isDefending: true,
+        currentRank: Rank.Three,
+        points: 0
+      };
+      const attackingTeam: Team = {
+        id: 'B',
+        players: [],
+        isDefending: false,
+        currentRank: Rank.Five,
+        points: 180
+      };
+
+      const gameState = createMockGameState(defendingTeam, attackingTeam);
+      const result = endRound(gameState);
+
+      expect(result.newState.teams[1].currentRank).toBe(Rank.Seven);
+      expect(result.newState.teams[1].isDefending).toBe(true);
+      expect(result.roundCompleteMessage).toContain('won with 180 points');
+      expect(result.roundCompleteMessage).toContain('advances 2 ranks to 7');
+    });
+
+    it('should advance attacking team by 3 ranks when they get 200+ points', () => {
+      const defendingTeam: Team = {
+        id: 'A',
+        players: [],
+        isDefending: true,
+        currentRank: Rank.Three,
+        points: 0
+      };
+      const attackingTeam: Team = {
+        id: 'B',
+        players: [],
+        isDefending: false,
+        currentRank: Rank.Five,
+        points: 220
+      };
+
+      const gameState = createMockGameState(defendingTeam, attackingTeam);
+      const result = endRound(gameState);
+
+      expect(result.newState.teams[1].currentRank).toBe(Rank.Eight);
+      expect(result.newState.teams[1].isDefending).toBe(true);
+      expect(result.roundCompleteMessage).toContain('won with 220 points');
+      expect(result.roundCompleteMessage).toContain('advances 3 ranks to 8');
+    });
+
+    it('should win the game when attacking team reaches Ace', () => {
+      const defendingTeam: Team = {
+        id: 'A',
+        players: [],
+        isDefending: true,
+        currentRank: Rank.Three,
+        points: 0
+      };
+      const attackingTeam: Team = {
+        id: 'B',
+        players: [],
+        isDefending: false,
+        currentRank: Rank.Queen,
+        points: 160
+      };
+
+      const gameState = createMockGameState(defendingTeam, attackingTeam);
+      const result = endRound(gameState);
+
+      expect(result.gameOver).toBe(true);
+      expect(result.winner).toBe('B');
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should end game when team at Ace would advance further', () => {
+      // Test defending team at Ace winning
+      const defendingAtAce = createMockGameState(
+        { id: 'A', players: [], isDefending: true, currentRank: Rank.Ace, points: 0 },
+        { id: 'B', players: [], isDefending: false, currentRank: Rank.Five, points: 0 }
+      );
+      const resultDefending = endRound(defendingAtAce);
+      expect(resultDefending.gameOver).toBe(true);
+      expect(resultDefending.winner).toBe('A');
+      expect(resultDefending.roundCompleteMessage).toBe('');
+
+      // Test attacking team at King winning with high points (would go beyond Ace)
+      const attackingAtKing = createMockGameState(
+        { id: 'A', players: [], isDefending: true, currentRank: Rank.Three, points: 0 },
+        { id: 'B', players: [], isDefending: false, currentRank: Rank.King, points: 160 }
+      );
+      const resultAttacking = endRound(attackingAtKing);
+      expect(resultAttacking.gameOver).toBe(true);
+      expect(resultAttacking.winner).toBe('B');
+      expect(resultAttacking.roundCompleteMessage).toBe('');
+
+      // Test attacking team at Queen winning with very high points (would go 2 ranks beyond Ace)
+      const attackingAtQueen = createMockGameState(
+        { id: 'A', players: [], isDefending: true, currentRank: Rank.Three, points: 0 },
+        { id: 'B', players: [], isDefending: false, currentRank: Rank.Queen, points: 200 }
+      );
+      const resultAttackingQueen = endRound(attackingAtQueen);
+      expect(resultAttackingQueen.gameOver).toBe(true);
+      expect(resultAttackingQueen.winner).toBe('B');
+      expect(resultAttackingQueen.roundCompleteMessage).toBe('');
+
+      // Test defending team at King defending against 0 points (would advance 3 ranks beyond Ace)
+      const defendingAtKing = createMockGameState(
+        { id: 'A', players: [], isDefending: true, currentRank: Rank.King, points: 0 },
+        { id: 'B', players: [], isDefending: false, currentRank: Rank.Five, points: 0 }
+      );
+      const resultDefendingKing = endRound(defendingAtKing);
+      expect(resultDefendingKing.gameOver).toBe(true);
+      expect(resultDefendingKing.winner).toBe('A');
+      expect(resultDefendingKing.roundCompleteMessage).toBe('');
+
+      // Test defending team at Queen defending with <40 points (would advance 2 ranks beyond Ace)
+      const defendingAtQueen = createMockGameState(
+        { id: 'A', players: [], isDefending: true, currentRank: Rank.Queen, points: 0 },
+        { id: 'B', players: [], isDefending: false, currentRank: Rank.Five, points: 30 }
+      );
+      const resultDefendingQueen = endRound(defendingAtQueen);
+      expect(resultDefendingQueen.gameOver).toBe(true);
+      expect(resultDefendingQueen.winner).toBe('A');
+      expect(resultDefendingQueen.roundCompleteMessage).toBe('');
+
+      // Test defending team at Ten defending with <40 points (advances to Ace exactly)
+      const defendingAtTen = createMockGameState(
+        { id: 'A', players: [], isDefending: true, currentRank: Rank.Ten, points: 0 },
+        { id: 'B', players: [], isDefending: false, currentRank: Rank.Five, points: 30 }
+      );
+      const resultDefendingTen = endRound(defendingAtTen);
+      expect(resultDefendingTen.gameOver).toBe(false);
+      expect(resultDefendingTen.winner).toBe(null);
+      expect(resultDefendingTen.newState.teams[0].currentRank).toBe(Rank.Queen);
+      expect(resultDefendingTen.roundCompleteMessage).toContain('advances 2 ranks to Q');
+    });
+
+    it('should handle exact point boundaries correctly', () => {
+      // Test 40 points (should be 1 rank advancement)
+      const gameState40 = createMockGameState(
+        { id: 'A', players: [], isDefending: true, currentRank: Rank.Three, points: 0 },
+        { id: 'B', players: [], isDefending: false, currentRank: Rank.Five, points: 40 }
+      );
+      const result40 = endRound(gameState40);
+      expect(result40.newState.teams[0].currentRank).toBe(Rank.Four);
+
+      // Test 80 points (attacking team wins, no advancement)
+      const gameState80 = createMockGameState(
+        { id: 'A', players: [], isDefending: true, currentRank: Rank.Three, points: 0 },
+        { id: 'B', players: [], isDefending: false, currentRank: Rank.Five, points: 80 }
+      );
+      const result80 = endRound(gameState80);
+      expect(result80.newState.teams[1].currentRank).toBe(Rank.Five);
+      expect(result80.newState.teams[1].isDefending).toBe(true);
+
+      // Test 120 points (attacking team wins, 1 rank advancement)
+      const gameState120 = createMockGameState(
+        { id: 'A', players: [], isDefending: true, currentRank: Rank.Three, points: 0 },
+        { id: 'B', players: [], isDefending: false, currentRank: Rank.Five, points: 120 }
+      );
+      const result120 = endRound(gameState120);
+      expect(result120.newState.teams[1].currentRank).toBe(Rank.Six);
+    });
+
+    it('should reset team points for the next round', () => {
+      const gameState = createMockGameState(
+        { id: 'A', players: [], isDefending: true, currentRank: Rank.Three, points: 25 },
+        { id: 'B', players: [], isDefending: false, currentRank: Rank.Five, points: 65 }
+      );
+      const result = endRound(gameState);
+
+      expect(result.newState.teams[0].points).toBe(0);
+      expect(result.newState.teams[1].points).toBe(0);
+    });
+  });
+});

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -164,6 +164,45 @@ The game uses React Native's Animated API for fluid card interactions:
 3. **Interpolation**: Translates animation progress to visual properties
 4. **Performance**: Uses native driver where possible for smooth performance
 
+## Scoring and Rank Advancement Rules
+
+### Point Scoring
+
+- **5s**: 5 points each
+- **10s and Kings**: 10 points each
+- **Other cards**: 0 points
+- **Target**: Attacking team needs 80+ points to win the round
+
+### Rank Advancement Rules
+
+#### When Defending Team Successfully Defends (Attackers < 80 points)
+
+The defending team advances based on the attacking team's points:
+
+- **40-79 points**: Defenders advance +1 rank
+- **< 40 points**: Defenders advance +2 ranks
+- **0 points**: Defenders advance +3 ranks
+
+#### When Attacking Team Wins (Attackers ≥ 80 points)
+
+The attacking team becomes the new defending team and:
+
+- **80-119 points**: Play at their current rank (no advancement)
+- **120-159 points**: Advance +1 rank
+- **160-199 points**: Advance +2 ranks
+- **Pattern**: For every additional 40 points beyond 80, advance +1 rank
+
+#### Examples
+
+Scenario: Team A at rank 5, Team B at rank 3 (defending)
+
+- Team A scores 60 points → Team B advances to rank 4, remains defending
+- Team A scores 25 points → Team B advances to rank 5, remains defending
+- Team A scores 0 points → Team B advances to rank 6, remains defending
+- Team A scores 100 points → Team A becomes defending at rank 5
+- Team A scores 140 points → Team A becomes defending at rank 6
+- Team A scores 180 points → Team A becomes defending at rank 7
+
 ## Performance Considerations
 
 - **Component Memoization**: Key components use React.memo to prevent unnecessary rerenders

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -112,3 +112,67 @@ The human player's thinking indicator briefly flashes when the human wins a tric
 - Consider deeper refactoring of state transition timing
 - Investigate if trick completion and UI state updates can be better synchronized
 - May require changes to how `currentPlayerIndex` is updated relative to UI state
+
+## Game Rules Issues
+
+### Next Round Starting Player
+
+**Status**: Known Issue
+
+**Description**:
+The game currently selects the first player from the defending team to start the next round, but this doesn't follow the correct Tractor/Shengji rules.
+
+**Technical Details**:
+- Current implementation in `gameRoundManager.ts` uses `defendingPlayers[0]`
+- Correct rules should be:
+  - **First round**: Trump declarer goes first, their team becomes defending
+  - **Following rounds**:
+    - If defending team defends: The OTHER player in defending team plays first
+    - If attacking team wins: The next player (clockwise) from attacking team plays first
+- Current implementation doesn't track who declared trump or alternate between teammates
+
+**Current State**:
+- Always selects first player from array of defending team players
+- Doesn't alternate between teammates when defending team wins
+- Doesn't rotate correctly when attacking team wins
+- May result in same player always going first
+
+**Example Issues**:
+- If Human & Bot2 (Team A) defend and win, Bot2 should play first next round, not Human
+- If Bot1 & Bot3 (Team B) attack and win, the next player after current should play first
+
+**Next Steps**:
+- Track trump declarer for first round
+- Implement teammate alternation for defending team wins
+- Implement clockwise rotation for attacking team wins
+- Add tests to verify correct player selection logic
+
+### Game Rotation Direction
+
+**Status**: Known Issue
+
+**Description**:
+The game currently uses clockwise rotation for player turns and next player selection, but traditional Tractor/Shengji is played counter-clockwise.
+
+**Technical Details**:
+- Current implementation rotates clockwise (Human → Bot1 → Bot2 → Bot3)
+- Traditional game should rotate counter-clockwise (Human → Bot3 → Bot2 → Bot1)
+- Affects:
+  - Turn order during tricks
+  - Next player selection when attacking team wins
+  - Player positioning expectations
+
+**Current State**:
+- All player rotations are clockwise
+- May confuse players familiar with traditional counter-clockwise play
+- Impacts strategic play as position-based strategies are reversed
+
+**Example Issues**:
+- When attacking team wins, next player is selected clockwise instead of counter-clockwise
+- During tricks, play proceeds clockwise instead of the traditional counter-clockwise
+
+**Next Steps**:
+- Update player rotation logic throughout the codebase
+- Modify next player selection to use counter-clockwise order
+- Update UI player positions if needed
+- Add tests to verify counter-clockwise rotation

--- a/src/components/HumanHandAnimated.tsx
+++ b/src/components/HumanHandAnimated.tsx
@@ -193,7 +193,7 @@ const HumanHandAnimated: React.FC<HumanHandAnimatedProps> = ({
               >
                 <AnimatedCardComponent
                   card={card}
-                  onSelect={isCurrentPlayer && isCardSelectableForTrump(card) && !showTrickResult && !lastCompletedTrick ? onCardSelect : undefined}
+                  onSelect={(trumpDeclarationMode || isCurrentPlayer) && isCardSelectableForTrump(card) && !showTrickResult && !lastCompletedTrick ? onCardSelect : undefined}
                   selected={isCardSelected(card)}
                   faceDown={false}
                   isTrump={isTrump(card, trumpInfo)}


### PR DESCRIPTION
## Summary
- Implement advanced rank advancement logic based on points
- Fix human card selection during declaring phase  
- Update documentation with detailed scoring rules
- Add comprehensive tests for edge cases
- Document known issues with game rules

## Changes Made

### Advanced Scoring Implementation
- Defending team advances +1/+2/+3 ranks based on attacker's points
- Attacking team advances based on points above 80 (40-point intervals)
- Proper handling of rank advancement beyond Ace

### Bug Fixes
- Fixed human card selection during declaring phase when not current player

### Documentation
- Added comprehensive scoring rules to ARCHITECTURE.md
- Documented known issues with player rotation and turn order

### Testing
- Added 12 new tests for advanced scoring scenarios
- Updated existing tests to match new scoring logic
- All tests passing

## Test plan
- [x] Run all existing tests
- [x] Add new tests for advanced scoring
- [x] Add edge case tests for rank advancement beyond Ace
- [x] Manual testing of declaring phase card selection

🤖 Generated with [Claude Code](https://claude.ai/code)