### PR TITLE
Add concurrency control to EAS Update workflow

### DIFF
--- a/.github/workflows/eas-update.yml
+++ b/.github/workflows/eas-update.yml
@@ -5,6 +5,11 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+# Prevent concurrent production deployments
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false  # Queue deployments instead of canceling
+
 jobs:
   eas-update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add concurrency control to prevent multiple production deployments
- Queue new deployments instead of canceling existing ones
- Ensures production updates complete in order

## Why?
- Prevents race conditions during deployment
- Ensures each deployment completes before the next one starts
- Avoids potential issues with partially completed updates

## Test plan
- Workflow syntax is valid
- Concurrency group name is descriptive
- Cancel-in-progress is set to false to queue deployments

🤖 Generated with [Claude Code](https://claude.ai/code)