### PR TITLE
Fix trick winner card highlight swap between Bot1 and Bot3

### DIFF
--- a/src/components/CardPlayArea.tsx
+++ b/src/components/CardPlayArea.tsx
@@ -309,7 +309,7 @@ const CardPlayArea: React.FC<CardPlayAreaProps> = ({
                       marginLeft: 15, // Smaller shift for tighter centering
                     }),
                     // Simple border for winning cards (works on Android)
-                    ...(isWinning(players.find(p => p.id === 'ai1')?.id || '') && {
+                    ...(isWinning(players.find(p => p.id === 'ai3')?.id || '') && {
                       borderWidth: 2,
                       borderColor: '#FFC107',
                       backgroundColor: 'rgba(255, 255, 255, 0.9)',
@@ -351,7 +351,7 @@ const CardPlayArea: React.FC<CardPlayAreaProps> = ({
                       marginLeft: 15, // Smaller shift for tighter centering
                     }),
                     // Simple border for winning cards (works on Android)
-                    ...(isWinning(players.find(p => p.id === 'ai3')?.id || '') && {
+                    ...(isWinning(players.find(p => p.id === 'ai1')?.id || '') && {
                       borderWidth: 2,
                       borderColor: '#FFC107',
                       backgroundColor: 'rgba(255, 255, 255, 0.9)',


### PR DESCRIPTION
## Summary
- Fixes #28 where card highlights were swapped between Bot1 and Bot3 when winning a trick

## Changes
- After the counter-clockwise rotation change, the card highlighting was not correctly updated
- Fixed by swapping the player ID checks in the winner highlighting logic
- Left cards now correctly check for ai3
- Right cards now correctly check for ai1

## Test plan
- [x] All existing tests pass
- [x] Checked that CardPlayArea tests pass
- [x] Manual verification confirms the fix

🤖 Generated with [Claude Code](https://claude.ai/code)