### PR TITLE
Fix: non-trump pair from different suits should not beat a proper pair

### DIFF
--- a/__tests__/game-logic/trumpPairs.test.ts
+++ b/__tests__/game-logic/trumpPairs.test.ts
@@ -2,7 +2,8 @@ import {
   getComboType,
   identifyCombos,
   isTrump,
-  compareCards
+  compareCards,
+  compareCardCombos
 } from '../../src/utils/gameLogic';
 import {
   Card,
@@ -357,5 +358,44 @@ describe('Trump Pair Tests', () => {
     );
 
     expect(invalidJokerPair).toBeUndefined();
+  });
+
+  // Test for Issue #34 - Non-trump pair from different suits should not beat a leading non-trump pair
+  test('A non-trump pair from different suits should not beat a leading non-trump pair', () => {
+    // Create a new trumpInfo where 5's aren't trump
+    const nonFiveTrumpInfo: TrumpInfo = {
+      trumpRank: Rank.Seven,
+      trumpSuit: Suit.Diamonds,
+      declared: true
+    };
+
+    // Create a proper pair of five spades (non-trump)
+    const properPair = [fiveSpades1, fiveSpades2];
+    
+    // Create an "invalid pair" of same rank but different suits (also non-trump)
+    const invalidPair = [
+      {
+        suit: Suit.Hearts,
+        rank: Rank.Five,
+        id: 'Hearts_5_1',
+        points: 5
+      },
+      {
+        suit: Suit.Clubs,
+        rank: Rank.Five,
+        id: 'Clubs_5_1',
+        points: 5
+      }
+    ];
+
+    // Verify proper pair is actually a pair
+    expect(getComboType(properPair)).toBe(ComboType.Pair);
+    
+    // Verify mixed-suit "pair" is not actually a pair
+    expect(getComboType(invalidPair)).toBe(ComboType.Single);
+    
+    // Test the key scenario - proper pair should beat mixed-suit non-pair
+    const comparison = compareCardCombos(properPair, invalidPair, nonFiveTrumpInfo);
+    expect(comparison).toBeGreaterThan(0); // properPair should win
   });
 });

--- a/src/utils/gameLogic.ts
+++ b/src/utils/gameLogic.ts
@@ -751,6 +751,30 @@ export const compareCardCombos = (comboA: Card[], comboB: Card[], trumpInfo: Tru
 
   // If different types of combos but same total cards, should already be handled above
   // This shouldn't happen in proper Shengji
+  
+  // Check for a specific case where both are marked as "singles" but one is actually
+  // multiple cards of the same suit and the other is mixed suits
+  if (comboA.length > 1) {
+    // For multi-card plays, the rule in Shengji is that the leading suit's play wins
+    // unless beaten by a trump play or a proper combo (like a pair)
+    
+    // Get the suit of the leading combo (the one that should win if no trump/proper combo)
+    const leadingSuit = getLeadingSuit([...comboA, ...comboB]);
+    
+    // If both are non-trump and we have a leading suit,
+    // the combo that follows the leading suit wins
+    if (leadingSuit && !aIsTrump && !bIsTrump) {
+      // Count how many cards match the leading suit in each combo
+      const aMatchCount = comboA.filter(card => card.suit === leadingSuit).length;
+      const bMatchCount = comboB.filter(card => card.suit === leadingSuit).length;
+      
+      // If one follows the suit better than the other, it wins
+      if (aMatchCount > bMatchCount) return 1;
+      if (aMatchCount < bMatchCount) return -1;
+    }
+  }
+  
+  // Default fallback: compare highest cards
   const maxCardA = comboA.reduce((max, card) =>
     compareCards(max, card, trumpInfo) > 0 ? max : card, comboA[0]
   );


### PR DESCRIPTION
## Summary
- Fixed issue where cards from different suits could incorrectly beat a proper pair from the same suit
- Changed the comparison logic to respect suit matching when neither play contains trump cards
- This ensures that playing two cards of different suits (which isn't a valid pair) can't beat a proper pair

## Test plan
- Added a specific test case in trumpPairs.test.ts to verify the fix
- Ran all existing tests to ensure this change doesn't break other functionality
- All quality checks pass: typecheck, lint, and tests

Fixes #34

🤖 Generated with [Claude Code](https://claude.ai/code)