### PR TITLE
Fix human cards not selectable during trump declaration in round 2

### DIFF
--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -94,7 +94,7 @@ export function useGameState(config: GameConfig) {
     const currentPlayer = gameState.players[gameState.currentPlayerIndex];
     
     // Handle trump declaration mode - select card but don't declare immediately
-    if (showTrumpDeclaration && currentPlayer.isHuman) {
+    if (showTrumpDeclaration) {
       if (card.rank === gameState.trumpInfo.trumpRank && card.suit) {
         // Toggle selection of trump cards
         if (selectedCards.some(c => c.id === card.id)) {


### PR DESCRIPTION
## Summary
- Fixed issue where human cards were not selectable during trump declaration in round 2
- Removed incorrect `currentPlayer.isHuman` check that was preventing card selection

## Problem
When Team B defends round 1 and starts round 2, human players couldn't select their trump rank cards for declaration. The cards were correctly displayed as selectable (only trump ranks), but clicking them had no effect.

## Solution
The bug was in the `handleCardSelect` function in `useGameState.ts`. It was checking if `currentPlayer.isHuman` before allowing card selection during trump declaration. This prevented the human from selecting cards when they weren't the first player of the round.

During trump declaration, any human player with trump rank cards should be able to select them, regardless of turn order.

## Test plan
- [x] Verified all existing tests pass
- [x] Manually tested that human can select trump rank cards in round 2
- [x] Confirmed fix works when human is not the first player of the round

Fixes #39

🤖 Generated with [Claude Code](https://claude.ai/code)