### PR TITLE
Fix trump strength rules to implement 'first played wins' for equal strength cards

### DIFF
--- a/__tests__/game-logic/trumpStrengthRules.test.ts
+++ b/__tests__/game-logic/trumpStrengthRules.test.ts
@@ -1,0 +1,143 @@
+import { Card, Rank, Suit, TrumpInfo, PlayerId, Trick, JokerType } from '../../src/types/game';
+import { compareCards, determineTrickWinner } from '../../src/utils/gameLogic';
+
+describe('Trump Strength Rules (Issue #37)', () => {
+  const trumpInfo: TrumpInfo = {
+    trumpRank: Rank.Two,
+    trumpSuit: Suit.Spades,
+    declared: true,
+  };
+
+  describe('Trump hierarchy', () => {
+    test('Big Joker > Small Joker > Trump rank in trump suit > Trump rank in other suits > Trump suit cards', () => {
+      const bigJoker: Card = { id: 'BJ1', joker: JokerType.Big, points: 0 };
+      const smallJoker: Card = { id: 'SJ1', joker: JokerType.Small, points: 0 };
+      const trumpRankInTrumpSuit: Card = { id: '2S1', rank: Rank.Two, suit: Suit.Spades, points: 0 };
+      const trumpRankInHearts: Card = { id: '2H1', rank: Rank.Two, suit: Suit.Hearts, points: 0 };
+      const trumpRankInClubs: Card = { id: '2C1', rank: Rank.Two, suit: Suit.Clubs, points: 0 };
+      const trumpRankInDiamonds: Card = { id: '2D1', rank: Rank.Two, suit: Suit.Diamonds, points: 0 };
+      const trumpSuitAce: Card = { id: 'AS1', rank: Rank.Ace, suit: Suit.Spades, points: 0 };
+      const nonTrumpCard: Card = { id: '5H1', rank: Rank.Five, suit: Suit.Hearts, points: 5 };
+
+      // Big Joker > Small Joker
+      expect(compareCards(bigJoker, smallJoker, trumpInfo)).toBeGreaterThan(0);
+
+      // Small Joker > Trump rank in trump suit
+      expect(compareCards(smallJoker, trumpRankInTrumpSuit, trumpInfo)).toBeGreaterThan(0);
+
+      // Trump rank in trump suit > Trump rank in other suits
+      expect(compareCards(trumpRankInTrumpSuit, trumpRankInHearts, trumpInfo)).toBeGreaterThan(0);
+      expect(compareCards(trumpRankInTrumpSuit, trumpRankInClubs, trumpInfo)).toBeGreaterThan(0);
+      expect(compareCards(trumpRankInTrumpSuit, trumpRankInDiamonds, trumpInfo)).toBeGreaterThan(0);
+
+      // Trump rank in other suits > Trump suit cards
+      expect(compareCards(trumpRankInHearts, trumpSuitAce, trumpInfo)).toBeGreaterThan(0);
+      expect(compareCards(trumpRankInClubs, trumpSuitAce, trumpInfo)).toBeGreaterThan(0);
+      expect(compareCards(trumpRankInDiamonds, trumpSuitAce, trumpInfo)).toBeGreaterThan(0);
+
+      // Trump suit cards > Non-trump cards
+      expect(compareCards(trumpSuitAce, nonTrumpCard, trumpInfo)).toBeGreaterThan(0);
+    });
+
+    test('Trump ranks in other suits have equal strength', () => {
+      const trumpRankInHearts: Card = { id: '2H1', rank: Rank.Two, suit: Suit.Hearts, points: 0 };
+      const trumpRankInClubs: Card = { id: '2C1', rank: Rank.Two, suit: Suit.Clubs, points: 0 };
+      const trumpRankInDiamonds: Card = { id: '2D1', rank: Rank.Two, suit: Suit.Diamonds, points: 0 };
+
+      // All trump ranks in non-trump suits should have equal strength (return 0)
+      expect(compareCards(trumpRankInHearts, trumpRankInClubs, trumpInfo)).toBe(0);
+      expect(compareCards(trumpRankInHearts, trumpRankInDiamonds, trumpInfo)).toBe(0);
+      expect(compareCards(trumpRankInClubs, trumpRankInDiamonds, trumpInfo)).toBe(0);
+    });
+  });
+
+  describe('First played wins rule', () => {
+    test('Issue #37 example: Human should win with 2D when played first', () => {
+      // Example from issue:
+      // Trump 2S
+      // Bot 3: 5S
+      // Human: 2D (trump rank in non-trump suit)
+      // Bot 1: 2C (trump rank in non-trump suit) 
+      // Bot 2: 9S
+
+      const trick: Trick = {
+        leadingPlayerId: PlayerId.Bot3,
+        leadingCombo: [{ id: '5S1', rank: Rank.Five, suit: Suit.Spades, points: 5 }],
+        plays: [
+          {
+            playerId: PlayerId.Human,
+            cards: [{ id: '2D1', rank: Rank.Two, suit: Suit.Diamonds, points: 0 }],
+          },
+          {
+            playerId: PlayerId.Bot1,
+            cards: [{ id: '2C1', rank: Rank.Two, suit: Suit.Clubs, points: 0 }],
+          },
+          {
+            playerId: PlayerId.Bot2,
+            cards: [{ id: '9S1', rank: Rank.Nine, suit: Suit.Spades, points: 0 }],
+          },
+        ],
+        points: 5,
+      };
+
+      const winner = determineTrickWinner(trick, trumpInfo);
+      
+      // Human should win because 2D (trump rank) was played first among trump rank cards
+      expect(winner).toBe(PlayerId.Human);
+    });
+
+    test('First trump rank card wins when multiple trump ranks played', () => {
+      const trick: Trick = {
+        leadingPlayerId: PlayerId.Bot1,
+        leadingCombo: [{ id: '2H1', rank: Rank.Two, suit: Suit.Hearts, points: 0 }],
+        plays: [
+          {
+            playerId: PlayerId.Bot2,
+            cards: [{ id: '2C1', rank: Rank.Two, suit: Suit.Clubs, points: 0 }],
+          },
+          {
+            playerId: PlayerId.Bot3,
+            cards: [{ id: '2D1', rank: Rank.Two, suit: Suit.Diamonds, points: 0 }],
+          },
+          {
+            playerId: PlayerId.Human,
+            cards: [{ id: '3H1', rank: Rank.Three, suit: Suit.Hearts, points: 0 }],
+          },
+        ],
+        points: 0,
+      };
+
+      const winner = determineTrickWinner(trick, trumpInfo);
+      
+      // Bot1 should win because they played the first trump rank card (2H)
+      expect(winner).toBe(PlayerId.Bot1);
+    });
+
+    test('Higher trump beats equal strength trump regardless of play order', () => {
+      const trick: Trick = {
+        leadingPlayerId: PlayerId.Human,
+        leadingCombo: [{ id: '2D1', rank: Rank.Two, suit: Suit.Diamonds, points: 0 }], // Trump rank in non-trump suit
+        plays: [
+          {
+            playerId: PlayerId.Bot1,
+            cards: [{ id: '2C1', rank: Rank.Two, suit: Suit.Clubs, points: 0 }], // Equal strength trump rank
+          },
+          {
+            playerId: PlayerId.Bot2,
+            cards: [{ id: '2S1', rank: Rank.Two, suit: Suit.Spades, points: 0 }], // Trump rank in trump suit (higher)
+          },
+          {
+            playerId: PlayerId.Bot3,
+            cards: [{ id: '5H1', rank: Rank.Five, suit: Suit.Hearts, points: 5 }], // Non-trump
+          },
+        ],
+        points: 5,
+      };
+
+      const winner = determineTrickWinner(trick, trumpInfo);
+      
+      // Bot2 should win because 2S (trump rank in trump suit) beats trump ranks in other suits
+      expect(winner).toBe(PlayerId.Bot2);
+    });
+  });
+});

--- a/src/utils/gameLogic.ts
+++ b/src/utils/gameLogic.ts
@@ -153,19 +153,18 @@ export const compareCards = (
       return aLevel - bLevel; // Higher level wins
     }
 
-    // Same level trumps - need to compare further
+    // Same level trumps - need to handle specific cases
     if (aLevel === 2) {
-      // Both are trump rank in non-trump suits - compare suits
-      if (cardA.suit && cardB.suit) {
-        return compareSuits(cardA.suit, cardB.suit, trumpInfo);
-      }
+      // Both are trump rank in non-trump suits - they have equal strength
+      // Return 0 to indicate equal strength (first played wins in trick context)
+      return 0;
     } else if (aLevel === 1) {
       // Both are trump suit - compare by rank
       return compareRanks(cardA.rank!, cardB.rank!);
+    } else {
+      // Same level jokers or trump rank in trump suit - equal strength
+      return 0;
     }
-
-    // Same type of jokers or other edge case - compare by ID
-    return cardA.id.localeCompare(cardB.id);
   }
 
   // Non-trump comparison
@@ -174,38 +173,8 @@ export const compareCards = (
     return compareRanks(cardA.rank!, cardB.rank!);
   }
 
-  // Different suits, and not trumps - first card played wins
-  // In Shengji, when following suit isn't possible, the first card played determines the suit
-  // so return 0 to indicate neither card has precedence based solely on value
+  // Different suits, and not trumps - equal strength (first played wins)
   return 0;
-};
-
-// Compare suits using rotated suit ordering based on the trump suit
-const compareSuits = (
-  suitA: Suit,
-  suitB: Suit,
-  trumpInfo?: TrumpInfo,
-): number => {
-  // Default suit order: maintains alternating black-red pattern
-  // Base order: Spades (black), Hearts (red), Clubs (black), Diamonds (red)
-  let suitOrder = [Suit.Spades, Suit.Hearts, Suit.Clubs, Suit.Diamonds];
-
-  // If we have a trump suit, rotate the order to put the trump suit first
-  // while maintaining the alternating black-red pattern
-  if (trumpInfo?.trumpSuit) {
-    const trumpSuitIndex = suitOrder.indexOf(trumpInfo.trumpSuit);
-    if (trumpSuitIndex > 0) {
-      // Rotate the array to put the trump suit first
-      suitOrder = [
-        ...suitOrder.slice(trumpSuitIndex),
-        ...suitOrder.slice(0, trumpSuitIndex),
-      ];
-    }
-  }
-
-  // Compare the suits in the (possibly rotated) order
-  // Higher index is higher value in Shengji
-  return suitOrder.indexOf(suitB) - suitOrder.indexOf(suitA);
 };
 
 // Compare ranks


### PR DESCRIPTION
## Summary
- Fixes issue #37: Implements proper "first played wins" rule for trump ranks of equal strength
- Modified trump card comparison logic to correctly handle equal strength scenarios

## Changes Made
- **Modified `compareCards()`**: Returns `0` for trump ranks in non-trump suits (equal strength) instead of comparing suits
- **Removed unused code**: Eliminated `compareSuits()` function that was incorrectly used for equal strength comparisons  
- **Added comprehensive tests**: New test suite covering trump hierarchy and first-played-wins scenarios

## Issue #37 Fix
**Problem**: When multiple players play trump rank cards in non-trump suits (equal strength), the game incorrectly used suit comparison instead of "first played wins"

**Example**: 
- Trump: 2♠
- Bot3: 5♠, Human: 2♦ (first), Bot1: 2♣ (second), Bot2: 9♠
- **Expected**: Human wins (2♦ played first)
- **Before**: Bot1 won (incorrect suit comparison)  
- **After**: ✅ Human wins (first played wins)

## Technical Solution
The fix elegantly leverages existing `determineTrickWinner()` logic:
- When `compareCards()` returns `0` (equal strength), the winner is not updated
- This naturally preserves the earlier-played card as winner
- No complex play-order tracking needed

## Test Coverage
- ✅ Complete trump hierarchy verification
- ✅ Equal strength trump rank comparisons
- ✅ First played wins scenarios  
- ✅ Mixed strength edge cases
- ✅ All 184 tests passing

🤖 Generated with [Claude Code](https://claude.ai/code)