### PR TITLE
Fix trump pair hierarchy: trump rank pairs now beat trump suit pairs

### DIFF
--- a/__tests__/game-logic/trumpPairHierarchy.test.ts
+++ b/__tests__/game-logic/trumpPairHierarchy.test.ts
@@ -1,0 +1,110 @@
+import { compareCardCombos } from '../../src/utils/gameLogic';
+import { Card, Suit, Rank, TrumpInfo, JokerType } from '../../src/types/game';
+import { createCard, createJoker, createPair } from '../helpers/testUtils';
+
+describe('Trump Pair Hierarchy Tests', () => {
+  // Test case for issue #49: Trump rank pairs vs trump suit pairs
+  describe('Issue #49: Trump rank pairs should beat trump suit pairs of different ranks', () => {
+    const trumpInfo: TrumpInfo = {
+      trumpRank: Rank.Two,
+      trumpSuit: Suit.Spades,
+      declared: true,
+      declarerPlayerId: 'test',
+    };
+
+    test('2♣-2♣ pair should beat Q♠-Q♠ pair (trump rank vs trump suit)', () => {
+      const trumpRankPair = createPair(Suit.Clubs, Rank.Two);
+      const trumpSuitPair = createPair(Suit.Spades, Rank.Queen);
+
+      // Trump rank pair should win over trump suit pair
+      const result = compareCardCombos(trumpRankPair, trumpSuitPair, trumpInfo);
+      expect(result).toBeGreaterThan(0); // trumpRankPair wins
+    });
+
+    test('2♥-2♥ pair should beat A♠-A♠ pair (trump rank vs trump suit)', () => {
+      const trumpRankPair = createPair(Suit.Hearts, Rank.Two);
+      const trumpSuitPair = createPair(Suit.Spades, Rank.Ace);
+
+      const result = compareCardCombos(trumpRankPair, trumpSuitPair, trumpInfo);
+      expect(result).toBeGreaterThan(0); // trumpRankPair wins
+    });
+
+    test('2♦-2♦ pair should beat 3♠-3♠ pair (trump rank vs trump suit)', () => {
+      const trumpRankPair = createPair(Suit.Diamonds, Rank.Two);
+      const trumpSuitPair = createPair(Suit.Spades, Rank.Three);
+
+      const result = compareCardCombos(trumpRankPair, trumpSuitPair, trumpInfo);
+      expect(result).toBeGreaterThan(0); // trumpRankPair wins
+    });
+  });
+
+  describe('Complete trump pair hierarchy verification', () => {
+    const trumpInfo: TrumpInfo = {
+      trumpRank: Rank.Two,
+      trumpSuit: Suit.Spades,
+      declared: true,
+      declarerPlayerId: 'test',
+    };
+
+    test('2♠-2♠ pair should beat 2♣-2♣ pair (trump rank in trump suit vs other suits)', () => {
+      const trumpRankInTrumpSuit = createPair(Suit.Spades, Rank.Two);
+      const trumpRankInOtherSuit = createPair(Suit.Clubs, Rank.Two);
+
+      const result = compareCardCombos(trumpRankInTrumpSuit, trumpRankInOtherSuit, trumpInfo);
+      expect(result).toBeGreaterThan(0); // trump suit trump rank wins
+    });
+
+    test('Small Joker pair should beat 2♠-2♠ pair', () => {
+      const smallJokerPair = [createJoker(JokerType.Small), createJoker(JokerType.Small)];
+      const trumpRankInTrumpSuit = createPair(Suit.Spades, Rank.Two);
+
+      const result = compareCardCombos(smallJokerPair, trumpRankInTrumpSuit, trumpInfo);
+      expect(result).toBeGreaterThan(0); // joker pair wins
+    });
+
+    test('Big Joker pair should beat Small Joker pair', () => {
+      const bigJokerPair = [createJoker(JokerType.Big), createJoker(JokerType.Big)];
+      const smallJokerPair = [createJoker(JokerType.Small), createJoker(JokerType.Small)];
+
+      const result = compareCardCombos(bigJokerPair, smallJokerPair, trumpInfo);
+      expect(result).toBeGreaterThan(0); // big joker pair wins
+    });
+
+    test('Trump rank pairs from different non-trump suits should be equal (first played wins)', () => {
+      const trumpRankClubs = createPair(Suit.Clubs, Rank.Two);
+      const trumpRankHearts = createPair(Suit.Hearts, Rank.Two);
+
+      // When trump rank cards from different non-trump suits are compared,
+      // they should be equal strength (first played wins)
+      const result = compareCardCombos(trumpRankClubs, trumpRankHearts, trumpInfo);
+      expect(result).toBe(0); // equal strength, first played wins
+    });
+  });
+
+  describe('Non-trump pairs should not be affected', () => {
+    const trumpInfo: TrumpInfo = {
+      trumpRank: Rank.Two,
+      trumpSuit: Suit.Spades,
+      declared: true,
+      declarerPlayerId: 'test',
+    };
+
+    test('Non-trump pairs comparison should remain unchanged', () => {
+      const heartsKings = createPair(Suit.Hearts, Rank.King);
+      const clubsQueens = createPair(Suit.Clubs, Rank.Queen);
+
+      // Non-trump pairs from different suits - leading combo should win
+      const result = compareCardCombos(heartsKings, clubsQueens, trumpInfo);
+      expect(result).toBeGreaterThan(0); // leading combo wins
+    });
+
+    test('Same suit non-trump pairs should compare by rank', () => {
+      const heartsKings = createPair(Suit.Hearts, Rank.King);
+      const heartsQueens = createPair(Suit.Hearts, Rank.Queen);
+
+      // Same suit pairs should compare by rank
+      const result = compareCardCombos(heartsKings, heartsQueens, trumpInfo);
+      expect(result).toBeGreaterThan(0); // Kings beat Queens
+    });
+  });
+});

--- a/src/utils/gameLogic.ts
+++ b/src/utils/gameLogic.ts
@@ -777,7 +777,11 @@ export const compareCardCombos = (
       ) {
         return compareRanks(comboA[0].rank, comboB[0].rank);
       } else {
-        // Different suits and both are pairs - in Shengji, the leading combo (comboA) wins
+        // Different suits and both are pairs - if both are trump pairs, compare by trump level
+        if (aIsTrump && bIsTrump) {
+          return compareCards(comboA[0], comboB[0], trumpInfo);
+        }
+        // Otherwise, in Shengji rules, the leading combo (comboA) wins
         return 1;
       }
     }


### PR DESCRIPTION
## Summary
Fixes issue #49 where trump rank pairs from non-trump suits were incorrectly losing to trump suit pairs of different ranks.

## Problem Description  
**Scenario:** Trump rank = 2, Trump suit = Spades ♠
- ❌ **Current**: Q♠-Q♠ beats 2♣-2♣ (incorrect)
- ✅ **Expected**: 2♣-2♣ should beat Q♠-Q♠ (trump rank beats trump suit)

## Root Cause Analysis
The issue was in `compareCardCombos()` at lines 780-781 in `src/utils/gameLogic.ts`. When comparing pairs from different suits, it defaulted to "leading combo wins" without considering trump hierarchy:

```typescript
// OLD CODE - Incorrect logic
} else {
  // Different suits and both are pairs - in Shengji, the leading combo (comboA) wins
  return 1;
}
```

This ignored the trump hierarchy levels that were already correctly implemented in `compareCards()` and `getTrumpLevel()`.

## Solution Implemented
Added proper trump hierarchy comparison for trump pairs from different suits:

```typescript
// NEW CODE - Fixed logic  
} else {
  // Different suits and both are pairs - if both are trump pairs, compare by trump level
  if (aIsTrump && bIsTrump) {
    return compareCards(comboA[0], comboB[0], trumpInfo);
  }
  // Otherwise, in Shengji rules, the leading combo (comboA) wins
  return 1;
}
```

## Trump Hierarchy Verification
The fix ensures correct trump pair hierarchy:

1. **Big Joker pair** (🃿🃿) - Highest  
2. **Small Joker pair** (🃏🃏)
3. **Trump rank in trump suit** (2♠-2♠ when rank=2, suit=♠)
4. **Trump rank in other suits** (2♣-2♣, 2♥-2♥, 2♦-2♦) - *Equal strength, first played wins*
5. **Trump suit cards** (Q♠-Q♠, K♠-K♠, etc.) - Lowest trump pairs

## Test Coverage
Added comprehensive test suite `trumpPairHierarchy.test.ts` with 9 tests:

**Issue #49 Specific Tests:**
- ✅ 2♣-2♣ beats Q♠-Q♠ (trump rank vs trump suit)
- ✅ 2♥-2♥ beats A♠-A♠ (trump rank vs trump suit)  
- ✅ 2♦-2♦ beats 3♠-3♠ (trump rank vs trump suit)

**Complete Hierarchy Tests:**
- ✅ 2♠-2♠ beats 2♣-2♣ (trump suit trump rank vs other suits)
- ✅ Small Joker pair beats 2♠-2♠
- ✅ Big Joker pair beats Small Joker pair
- ✅ Trump rank pairs from different non-trump suits are equal (first played wins)

**Regression Tests:**
- ✅ Non-trump pairs unchanged (leading combo wins for different suits)
- ✅ Same suit pairs still compare by rank

## Impact Assessment
- **✅ Fixes core game logic bug** affecting trump hierarchy rules
- **✅ No breaking changes** - non-trump pair logic unchanged
- **✅ All 201 tests passing** - no regressions introduced
- **✅ Maintains game balance** - follows traditional Shengji/Tractor rules

## Files Changed
- `src/utils/gameLogic.ts` - 4 lines added to fix comparison logic
- `__tests__/game-logic/trumpPairHierarchy.test.ts` - 110 lines of comprehensive tests

Closes #49

🤖 Generated with [Claude Code](https://claude.ai/code)