### PR TITLE
Implement smart card auto-selection for pairs and tractors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,13 +109,21 @@ npx eas --version
    - Points: 5s = 5pts, 10s and Kings = 10pts
    - Trump hierarchy: Big Joker > Small Joker > Trump rank in trump suit > Trump rank in other suits > Trump suit cards
 
-3. **Combination Rules**
+3. **Smart Card Selection**
+   - **Auto-selection**: Tapping a card automatically selects related cards to form optimal combinations
+   - **When leading**: Prioritizes tractors over pairs for better play
+   - **When following**: Auto-selects matching combination type if possible
+   - **Toggle behavior**: Tap selected card again to deselect
+   - **Fallback**: Single card selection when no combinations available
+   - **Implementation**: `cardAutoSelection.ts` utility with combination detection logic
+
+4. **Combination Rules**
    - **Singles**: Any card
    - **Pairs**: Two identical cards (same rank AND suit)
    - **Tractors**: Consecutive pairs of same suit
    - Special: SJ-SJ-BJ-BJ forms highest tractor
 
-4. **Game Flow**
+5. **Game Flow**
    - Phases: dealing → declaring → playing → scoring → gameOver
    - Teams alternate between defending and attacking
    - Trick winner leads next trick

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A React Native implementation of the Chinese card game Shengji (升级), also kn
 - 🎴 **Smooth card animations** with React Native Animated API
 - 👑 **Round starting player indicator** for clear game flow
 - 🎯 **Current player highlighting** with thinking indicators
-- 🃏 **Intuitive card selection** with validation feedback
+- 🃏 **Smart card auto-selection** for pairs and tractors
 - 📱 **Mobile-optimized UI** designed for touch interaction
 - 🎨 **Team color coding** (Green for Team A, Red for Team B)
 
@@ -85,6 +85,13 @@ Trump cards beat non-trump cards. Within trumps, the hierarchy is:
 - **Consecutive pairs** of the same suit
 - ✅ Valid: 7♥7♥-8♥8♥ or Small Joker pair + Big Joker pair
 - ❌ Invalid: Different suits, non-consecutive ranks, mixed trump/non-trump
+
+### Smart Card Selection
+- **Auto-selection**: Tap any card in a pair → both cards selected automatically
+- **Tractor priority**: When leading, prioritizes tractors over pairs for optimal play
+- **Following combinations**: Auto-selects matching combination type when possible
+- **Toggle control**: Tap selected card again to deselect and choose manually
+- **Fallback**: Single card selection when no combinations available
 
 ### Scoring & Advancement
 - **Points**: 5s = 5pts, 10s & Kings = 10pts

--- a/__tests__/utils/cardAutoSelection.test.ts
+++ b/__tests__/utils/cardAutoSelection.test.ts
@@ -1,0 +1,300 @@
+import {
+  findPairCards,
+  findTractorCards,
+  getAutoSelectedCards
+} from '../../src/utils/cardAutoSelection';
+import { Card, Suit, Rank, TrumpInfo, JokerType, ComboType } from '../../src/types/game';
+import { createCard, createJoker, createPair, createTrumpInfo } from '../helpers/testUtils';
+
+describe('Card Auto-Selection Utils', () => {
+  describe('findPairCards', () => {
+    test('should find regular pair cards', () => {
+      const hand = [
+        createCard(Suit.Hearts, Rank.King, 'hk1'),
+        createCard(Suit.Hearts, Rank.King, 'hk2'),
+        createCard(Suit.Spades, Rank.Ace),
+        createCard(Suit.Clubs, Rank.Five),
+      ];
+      
+      const targetCard = hand[0]; // First King of Hearts
+      const pairs = findPairCards(targetCard, hand);
+      
+      expect(pairs).toHaveLength(2);
+      expect(pairs).toContain(hand[0]);
+      expect(pairs).toContain(hand[1]);
+    });
+
+    test('should find joker pairs', () => {
+      const hand = [
+        createJoker(JokerType.Small, 'sj1'),
+        createJoker(JokerType.Small, 'sj2'),
+        createJoker(JokerType.Big),
+        createCard(Suit.Hearts, Rank.Ace),
+      ];
+      
+      const targetCard = hand[0]; // First Small Joker
+      const pairs = findPairCards(targetCard, hand);
+      
+      expect(pairs).toHaveLength(2);
+      expect(pairs).toContain(hand[0]);
+      expect(pairs).toContain(hand[1]);
+    });
+
+    test('should return only target card if no pairs exist', () => {
+      const hand = [
+        createCard(Suit.Hearts, Rank.King),
+        createCard(Suit.Spades, Rank.Queen),
+        createCard(Suit.Clubs, Rank.Ace),
+      ];
+      
+      const targetCard = hand[0];
+      const pairs = findPairCards(targetCard, hand);
+      
+      expect(pairs).toHaveLength(1);
+      expect(pairs).toContain(targetCard);
+    });
+
+    test('should not include cards of same rank but different suit', () => {
+      const hand = [
+        createCard(Suit.Hearts, Rank.King),
+        createCard(Suit.Spades, Rank.King), // Same rank, different suit
+        createCard(Suit.Clubs, Rank.Ace),
+      ];
+      
+      const targetCard = hand[0];
+      const pairs = findPairCards(targetCard, hand);
+      
+      expect(pairs).toHaveLength(1);
+      expect(pairs).toContain(targetCard);
+    });
+  });
+
+  describe('findTractorCards', () => {
+    const trumpInfo = createTrumpInfo(Rank.Two, Suit.Spades, true);
+
+    test('should find regular tractor (consecutive pairs)', () => {
+      const hand = [
+        ...createPair(Suit.Hearts, Rank.Seven),
+        ...createPair(Suit.Hearts, Rank.Eight),
+        createCard(Suit.Spades, Rank.Ace),
+      ];
+      
+      const targetCard = hand[0]; // Seven of Hearts
+      const tractor = findTractorCards(targetCard, hand, trumpInfo);
+      
+      expect(tractor).toHaveLength(4);
+      // Should include both 7-7 and 8-8 pairs
+      const ranks = tractor.map(c => c.rank);
+      expect(ranks.filter(r => r === Rank.Seven)).toHaveLength(2);
+      expect(ranks.filter(r => r === Rank.Eight)).toHaveLength(2);
+    });
+
+    test('should find joker tractor', () => {
+      const hand = [
+        createJoker(JokerType.Small, 'sj1'),
+        createJoker(JokerType.Small, 'sj2'),
+        createJoker(JokerType.Big, 'bj1'),
+        createJoker(JokerType.Big, 'bj2'),
+        createCard(Suit.Hearts, Rank.Ace),
+      ];
+      
+      const targetCard = hand[0]; // Small Joker
+      const tractor = findTractorCards(targetCard, hand, trumpInfo);
+      
+      expect(tractor).toHaveLength(4);
+      expect(tractor.filter(c => c.joker === JokerType.Small)).toHaveLength(2);
+      expect(tractor.filter(c => c.joker === JokerType.Big)).toHaveLength(2);
+    });
+
+    test('should return empty array for non-consecutive pairs', () => {
+      const hand = [
+        ...createPair(Suit.Hearts, Rank.Seven),
+        ...createPair(Suit.Hearts, Rank.Nine), // Gap - no Eight
+        createCard(Suit.Spades, Rank.Ace),
+      ];
+      
+      const targetCard = hand[0]; // Seven of Hearts
+      const tractor = findTractorCards(targetCard, hand, trumpInfo);
+      
+      expect(tractor).toHaveLength(0);
+    });
+
+    test('should return empty array for different suits', () => {
+      const hand = [
+        ...createPair(Suit.Hearts, Rank.Seven),
+        ...createPair(Suit.Spades, Rank.Eight), // Different suit
+      ];
+      
+      const targetCard = hand[0]; // Seven of Hearts
+      const tractor = findTractorCards(targetCard, hand, trumpInfo);
+      
+      expect(tractor).toHaveLength(0);
+    });
+
+    test('should find longer tractors', () => {
+      const hand = [
+        ...createPair(Suit.Hearts, Rank.Five),
+        ...createPair(Suit.Hearts, Rank.Six),
+        ...createPair(Suit.Hearts, Rank.Seven),
+        createCard(Suit.Spades, Rank.Ace),
+      ];
+      
+      const targetCard = hand[0]; // Five of Hearts
+      const tractor = findTractorCards(targetCard, hand, trumpInfo);
+      
+      expect(tractor).toHaveLength(6); // Three consecutive pairs
+      const ranks = tractor.map(c => c.rank);
+      expect(ranks.filter(r => r === Rank.Five)).toHaveLength(2);
+      expect(ranks.filter(r => r === Rank.Six)).toHaveLength(2);
+      expect(ranks.filter(r => r === Rank.Seven)).toHaveLength(2);
+    });
+  });
+
+  describe('getAutoSelectedCards', () => {
+    const trumpInfo = createTrumpInfo(Rank.Two, Suit.Spades, true);
+
+    test('should toggle off already selected card', () => {
+      const hand = [createCard(Suit.Hearts, Rank.King)];
+      const currentSelection = [hand[0]];
+      
+      const result = getAutoSelectedCards(
+        hand[0], hand, currentSelection, true, undefined, trumpInfo
+      );
+      
+      expect(result).toHaveLength(0);
+    });
+
+    test('should auto-select pair when leading', () => {
+      const hand = [
+        ...createPair(Suit.Hearts, Rank.King),
+        createCard(Suit.Spades, Rank.Ace),
+      ];
+      
+      const result = getAutoSelectedCards(
+        hand[0], hand, [], true, undefined, trumpInfo
+      );
+      
+      expect(result).toHaveLength(2);
+      expect(result).toContain(hand[0]);
+      expect(result).toContain(hand[1]);
+    });
+
+    test('should auto-select tractor when leading', () => {
+      const hand = [
+        ...createPair(Suit.Hearts, Rank.Seven),
+        ...createPair(Suit.Hearts, Rank.Eight),
+        createCard(Suit.Spades, Rank.Ace),
+      ];
+      
+      const result = getAutoSelectedCards(
+        hand[0], hand, [], true, undefined, trumpInfo
+      );
+      
+      expect(result).toHaveLength(4); // Tractor takes priority over pair
+    });
+
+    test('should auto-select pair when tapping card that can form pair while following pair', () => {
+      const hand = [
+        ...createPair(Suit.Hearts, Rank.King),
+        createCard(Suit.Hearts, Rank.Ace),
+      ];
+      
+      const leadingCombo = createPair(Suit.Spades, Rank.Queen);
+      
+      // Click on the first King - should auto-select both Kings
+      const result = getAutoSelectedCards(
+        hand[0], hand, [], false, leadingCombo, trumpInfo
+      );
+      
+      expect(result).toHaveLength(2);
+      expect(result).toContain(hand[0]);
+      expect(result).toContain(hand[1]);
+    });
+
+    test('should auto-select tractor when tapping card that can form tractor while following tractor', () => {
+      const hand = [
+        ...createPair(Suit.Hearts, Rank.Seven),
+        ...createPair(Suit.Hearts, Rank.Eight),
+        createCard(Suit.Hearts, Rank.Nine),
+      ];
+      
+      const leadingCombo = [
+        ...createPair(Suit.Spades, Rank.King),
+        ...createPair(Suit.Spades, Rank.Ace)
+      ];
+      
+      // Click on Seven of Hearts - should auto-select the 7-7-8-8 tractor
+      const result = getAutoSelectedCards(
+        hand[0], hand, [], false, leadingCombo, trumpInfo
+      );
+      
+      expect(result).toHaveLength(4);
+    });
+
+    test('should select single card when no combinations available', () => {
+      const hand = [
+        createCard(Suit.Hearts, Rank.King),
+        createCard(Suit.Spades, Rank.Queen),
+        createCard(Suit.Clubs, Rank.Ace),
+      ];
+      
+      const result = getAutoSelectedCards(
+        hand[0], hand, [], true, undefined, trumpInfo
+      );
+      
+      expect(result).toHaveLength(1);
+      expect(result).toContain(hand[0]);
+    });
+
+    test('should handle trump declaration mode with single selection', () => {
+      const hand = [createCard(Suit.Hearts, Rank.Two)];
+      const trumpInfoUndeclared = createTrumpInfo(Rank.Two, undefined, false);
+      
+      const result = getAutoSelectedCards(
+        hand[0], hand, [], true, undefined, trumpInfoUndeclared
+      );
+      
+      expect(result).toHaveLength(1);
+      expect(result).toContain(hand[0]);
+    });
+
+    test('should fall back to single selection when following pair but clicked card cannot form pair', () => {
+      const hand = [
+        createCard(Suit.Hearts, Rank.King),
+        createCard(Suit.Spades, Rank.Queen),
+      ];
+      
+      const leadingCombo = createPair(Suit.Clubs, Rank.Ace);
+      
+      // Click on King of Hearts - no pair available, should select single card
+      const result = getAutoSelectedCards(
+        hand[0], hand, [], false, leadingCombo, trumpInfo
+      );
+      
+      expect(result).toHaveLength(1);
+      expect(result).toContain(hand[0]);
+    });
+
+    test('should fall back to single selection when following tractor but clicked card cannot form tractor', () => {
+      const hand = [
+        createCard(Suit.Hearts, Rank.King),
+        createCard(Suit.Spades, Rank.Queen),
+        createCard(Suit.Clubs, Rank.Ace),
+      ];
+      
+      const leadingCombo = [
+        ...createPair(Suit.Spades, Rank.King),
+        ...createPair(Suit.Spades, Rank.Ace)
+      ];
+      
+      // Click on King of Hearts - no tractor available, should select single card
+      const result = getAutoSelectedCards(
+        hand[0], hand, [], false, leadingCombo, trumpInfo
+      );
+      
+      expect(result).toHaveLength(1);
+      expect(result).toContain(hand[0]);
+    });
+  });
+
+});

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -8,6 +8,7 @@ import {
   humanHasTrumpRank,
 } from "../utils/trumpManager";
 import { processPlay, validatePlay } from "../utils/gamePlayManager";
+import { getAutoSelectedCards } from "../utils/cardAutoSelection";
 import {
   TRICK_RESULT_DISPLAY_TIME,
   CARD_SELECTION_DELAY,
@@ -90,12 +91,24 @@ export function useGameState() {
     // Only allow current player to select cards
     if (!currentPlayer.isHuman) return;
 
-    // Toggle card selection
-    if (selectedCards.some((c) => c.id === card.id)) {
-      setSelectedCards(selectedCards.filter((c) => c.id !== card.id));
-    } else {
-      setSelectedCards([...selectedCards, card]);
-    }
+    // Determine if player is leading this trick
+    const isLeading =
+      !gameState.currentTrick || gameState.currentTrick.plays.length === 0;
+
+    // Get leading combo if following
+    const leadingCombo = gameState.currentTrick?.leadingCombo;
+
+    // Use smart auto-selection logic
+    const newSelection = getAutoSelectedCards(
+      card,
+      currentPlayer.hand,
+      selectedCards,
+      isLeading,
+      leadingCombo,
+      gameState.trumpInfo,
+    );
+
+    setSelectedCards(newSelection);
   };
 
   // Handle play button click

--- a/src/utils/cardAutoSelection.ts
+++ b/src/utils/cardAutoSelection.ts
@@ -1,0 +1,188 @@
+import { Card, TrumpInfo, Rank, JokerType, ComboType } from "../types/game";
+import { getComboType } from "./gameLogic";
+
+/**
+ * Utility functions for smart card auto-selection
+ */
+
+/**
+ * Finds all cards that form a pair with the given card
+ */
+export const findPairCards = (targetCard: Card, hand: Card[]): Card[] => {
+  const pairs: Card[] = [targetCard];
+
+  // Find joker pairs
+  if (targetCard.joker) {
+    const matchingJokers = hand.filter(
+      (card) => card.joker === targetCard.joker && card.id !== targetCard.id,
+    );
+    pairs.push(...matchingJokers);
+  }
+  // Find regular pairs (same rank and suit)
+  else if (targetCard.rank && targetCard.suit) {
+    const matchingCards = hand.filter(
+      (card) =>
+        card.rank === targetCard.rank &&
+        card.suit === targetCard.suit &&
+        card.id !== targetCard.id,
+    );
+    pairs.push(...matchingCards);
+  }
+
+  return pairs;
+};
+
+/**
+ * Finds all cards that form a tractor starting with the given card
+ */
+export const findTractorCards = (
+  targetCard: Card,
+  hand: Card[],
+  trumpInfo: TrumpInfo,
+): Card[] => {
+  // Special case: Joker tractor (Small Joker pair + Big Joker pair)
+  if (targetCard.joker) {
+    const smallJokers = hand.filter((card) => card.joker === JokerType.Small);
+    const bigJokers = hand.filter((card) => card.joker === JokerType.Big);
+
+    if (smallJokers.length >= 2 && bigJokers.length >= 2) {
+      return [...smallJokers.slice(0, 2), ...bigJokers.slice(0, 2)];
+    }
+    return [];
+  }
+
+  if (!targetCard.rank || !targetCard.suit) return [];
+
+  // Group cards by rank and suit to find pairs
+  const cardsByRankSuit = new Map<string, Card[]>();
+  hand.forEach((card) => {
+    if (card.rank && card.suit) {
+      const key = `${card.rank}-${card.suit}`;
+      if (!cardsByRankSuit.has(key)) {
+        cardsByRankSuit.set(key, []);
+      }
+      cardsByRankSuit.get(key)!.push(card);
+    }
+  });
+
+  // Find pairs only (need exactly 2 cards of same rank/suit)
+  const availablePairs = new Map<string, Card[]>();
+  cardsByRankSuit.forEach((cards, key) => {
+    if (cards.length >= 2) {
+      availablePairs.set(key, cards.slice(0, 2));
+    }
+  });
+
+  const targetKey = `${targetCard.rank}-${targetCard.suit}`;
+  if (!availablePairs.has(targetKey)) return [];
+
+  // Get rank order for consecutive checking
+  const rankOrder = [
+    Rank.Two,
+    Rank.Three,
+    Rank.Four,
+    Rank.Five,
+    Rank.Six,
+    Rank.Seven,
+    Rank.Eight,
+    Rank.Nine,
+    Rank.Ten,
+    Rank.Jack,
+    Rank.Queen,
+    Rank.King,
+    Rank.Ace,
+  ];
+
+  const targetRankIndex = rankOrder.indexOf(targetCard.rank);
+  if (targetRankIndex === -1) return [];
+
+  // Look for consecutive pairs in the same suit
+  const tractorCards: Card[] = [];
+  let currentRankIndex = targetRankIndex;
+
+  // Add the starting pair
+  tractorCards.push(...availablePairs.get(targetKey)!);
+
+  // Look for consecutive pairs going up
+  while (currentRankIndex + 1 < rankOrder.length) {
+    const nextRank = rankOrder[currentRankIndex + 1];
+    const nextKey = `${nextRank}-${targetCard.suit}`;
+
+    if (availablePairs.has(nextKey)) {
+      tractorCards.push(...availablePairs.get(nextKey)!);
+      currentRankIndex++;
+    } else {
+      break;
+    }
+  }
+
+  // A tractor needs at least 2 consecutive pairs (4 cards)
+  return tractorCards.length >= 4 ? tractorCards : [];
+};
+
+/**
+ * Determines what cards should be auto-selected when a player clicks a card
+ */
+export const getAutoSelectedCards = (
+  clickedCard: Card,
+  hand: Card[],
+  currentSelection: Card[],
+  isLeading: boolean,
+  leadingCombo?: Card[],
+  trumpInfo?: TrumpInfo,
+): Card[] => {
+  // If card is already selected, remove it (toggle off)
+  if (currentSelection.some((c) => c.id === clickedCard.id)) {
+    return currentSelection.filter((c) => c.id !== clickedCard.id);
+  }
+
+  // Special handling during trump declaration - single selection only
+  if (!trumpInfo?.declared) {
+    return [clickedCard];
+  }
+
+  // If following a specific combo type, try to match that type ONLY if the clicked card can form it
+  if (!isLeading && leadingCombo && leadingCombo.length > 1) {
+    const leadingComboType = getComboType(leadingCombo);
+
+    // Following a pair - auto-select pair only if clicked card can form a pair
+    if (leadingComboType === ComboType.Pair && leadingCombo.length === 2) {
+      const pairCards = findPairCards(clickedCard, hand);
+      if (pairCards.length === 2) {
+        return pairCards;
+      }
+      // If clicked card can't form a pair, fall through to single selection
+    }
+
+    // Following a tractor - auto-select tractor only if clicked card can form a tractor
+    if (
+      leadingComboType === ComboType.Tractor &&
+      leadingCombo.length === 4 &&
+      trumpInfo
+    ) {
+      const tractorCards = findTractorCards(clickedCard, hand, trumpInfo);
+      if (tractorCards.length === 4) {
+        return tractorCards;
+      }
+      // If clicked card can't form a tractor, fall through to single selection
+    }
+  }
+
+  // When leading, prioritize tractors over pairs for better combinations
+  if (isLeading && trumpInfo) {
+    // Try tractor first (more valuable combination)
+    const tractorCards = findTractorCards(clickedCard, hand, trumpInfo);
+    if (tractorCards.length >= 4) {
+      return tractorCards;
+    }
+
+    // Fall back to pair
+    const pairCards = findPairCards(clickedCard, hand);
+    if (pairCards.length === 2) {
+      return pairCards;
+    }
+  }
+
+  // Default: single card selection
+  return [clickedCard];
+};


### PR DESCRIPTION
## Summary
Implements intelligent card auto-selection that automatically selects pairs and tractors when players tap cards that can form these combinations.

Closes #48

## Key Features

### 🎯 Smart Selection Logic
- **When leading**: Prioritizes tractors over pairs for optimal play
- **When following pairs**: Auto-selects pair if tapped card can form one  
- **When following tractors**: Auto-selects tractor if tapped card can form one
- **Fallback**: Single card selection when no combinations possible

### 🎮 User Experience
- Tap any card in a pair → both cards automatically selected
- Tap first card of a tractor → entire tractor automatically selected
- Toggle functionality: tap selected card again to deselect
- Maintains manual override capability through deselection

### 🔧 Technical Implementation
- **New utility**: `cardAutoSelection.ts` with combination detection logic
- **Enhanced hook**: Updated `useGameState.ts` card selection handler  
- **Smart detection**: Handles joker pairs, joker tractors, and consecutive pairs
- **Respects game flow**: Different behavior for leading vs following

## Implementation Details

### Core Functions
- `findPairCards()`: Detects identical cards (same rank + suit)
- `findTractorCards()`: Detects consecutive pairs in same suit
- `getAutoSelectedCards()`: Main logic determining what to select

### Selection Behavior
```typescript
// When leading - prioritizes best combinations
clickCard(7♥) → selects 7♥-7♥-8♥-8♥ tractor (if available)
clickCard(K♠) → selects K♠-K♠ pair (if available)

// When following pair lead - matches combination type  
leadingCombo: Q♣-Q♣
clickCard(K♠) → selects K♠-K♠ pair (if available)

// When following tractor lead - matches combination type
leadingCombo: 9♦-9♦-10♦-10♦  
clickCard(7♥) → selects 7♥-7♥-8♥-8♥ tractor (if available)
```

## Test Coverage
- **18 comprehensive tests** covering all scenarios
- Tests pair detection, tractor detection, and edge cases
- Verifies correct behavior when following vs leading
- **All 219 tests passing** - no regressions

## Files Changed
- 🆕 `src/utils/cardAutoSelection.ts` (188 lines)
- ✏️ `src/hooks/useGameState.ts` (modified card selection logic)
- 🧪 `__tests__/utils/cardAutoSelection.test.ts` (300 lines of tests)

## Backward Compatibility
- ✅ Maintains existing trump declaration behavior (single selection)
- ✅ Preserves manual card selection when no combinations available
- ✅ No breaking changes to existing game logic
- ✅ All existing tests continue to pass

## User Impact
This significantly improves the user experience by reducing manual card selection work while maintaining full control. Players can now focus on strategy rather than tedious card selection, especially for complex combinations like tractors.

🤖 Generated with [Claude Code](https://claude.ai/code)