### PR TITLE
Fix bash variable scoping in EAS workflow version counting

### DIFF
--- a/.github/workflows/eas-update.yml
+++ b/.github/workflows/eas-update.yml
@@ -114,7 +114,7 @@ jobs:
         jq '.expo.extra.version = "${{ steps.vars.outputs.VERSION }}" | .expo.extra.gitCommit = "${{ steps.vars.outputs.GIT_COMMIT }}"' app.json > app.json.tmp
         mv app.json.tmp app.json
         echo "Injected version ${{ steps.vars.outputs.VERSION }} into app.json"
-        
+
     - name: EAS Update
       run: npx eas update --branch ${{ steps.vars.outputs.EAS_BRANCH }} --message "${{ steps.vars.outputs.EAS_MESSAGE }}"
       env:

--- a/.github/workflows/eas-update.yml
+++ b/.github/workflows/eas-update.yml
@@ -54,17 +54,15 @@ jobs:
         GIT_COMMIT=$(git rev-parse HEAD)
         echo "GIT_COMMIT=$GIT_COMMIT" >> $GITHUB_OUTPUT
         
-        # Helper function to get base version and commit count
-        get_version_info() {
-          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          if [[ -n "$LAST_TAG" ]]; then
-            BASE_VERSION=${LAST_TAG#v}
-            COMMIT_COUNT=$(git rev-list --count ${LAST_TAG}..HEAD)
-          else
-            BASE_VERSION="1.0.0"
-            COMMIT_COUNT=$(git rev-list --count HEAD)
-          fi
-        }
+        # Get base version and commit count
+        LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+        if [[ -n "$LAST_TAG" ]]; then
+          BASE_VERSION=${LAST_TAG#v}
+          COMMIT_COUNT=$(git rev-list --count ${LAST_TAG}..HEAD)
+        else
+          BASE_VERSION="1.0.0"
+          COMMIT_COUNT=$(git rev-list --count HEAD)
+        fi
         
         # Determine deployment based on trigger
         if [[ $GITHUB_REF == refs/tags/v* ]]; then
@@ -75,14 +73,12 @@ jobs:
           
         elif [[ $GITHUB_REF == refs/heads/main ]]; then
           # Beta release from main
-          get_version_info
           VERSION="v${BASE_VERSION}-beta.${COMMIT_COUNT}"
           EAS_BRANCH="beta"
           MESSAGE="Beta release $VERSION"
           
         elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
           # Alpha build from PR
-          get_version_info
           BRANCH_NAME="${{ github.head_ref }}"
           ALPHA_ID=${BRANCH_NAME//\//.}
           VERSION="v${BASE_VERSION}-alpha.${ALPHA_ID}.${COMMIT_COUNT}"
@@ -91,7 +87,6 @@ jobs:
           
         else
           # Alpha build from other branch
-          get_version_info
           BRANCH_NAME="${{ inputs.branch_name }}"
           if [[ -z "$BRANCH_NAME" ]]; then
             BRANCH_NAME=${GITHUB_REF#refs/heads/}


### PR DESCRIPTION
## Summary
- Fixes the bash variable scoping issue causing incorrect version counting
- Should resolve `v1.0.0-beta.1` showing instead of `v1.0.0-beta.88+`

## Problem
The `get_version_info()` function was creating local variables that weren't accessible outside the function scope, causing `BASE_VERSION` and `COMMIT_COUNT` to be undefined when used in the version string construction.

## Root Cause
```bash
# This created local variables:
get_version_info() {
  BASE_VERSION="1.0.0"        # ← Local scope
  COMMIT_COUNT=$(git rev-list --count HEAD)  # ← Local scope
}

# These were undefined here:
VERSION="v${BASE_VERSION}-beta.${COMMIT_COUNT}"  # ← Empty variables
```

## Solution
- Remove function wrapper and calculate variables in global scope
- `BASE_VERSION` and `COMMIT_COUNT` now accessible throughout the script
- Should show correct commit count based on git history

## Expected Result
- **Before**: `v1.0.0-beta.1` (incorrect)
- **After**: `v1.0.0-beta.88` (correct total commit count)

## Test Plan
- [ ] Deploy and verify version shows correct commit count
- [ ] Confirm no other workflow functionality is affected

🤖 Generated with [Claude Code](https://claude.ai/code)