### PR TITLE
Fix shallow clone issue in EAS workflow for accurate commit counting

### DIFF
--- a/.github/workflows/eas-update.yml
+++ b/.github/workflows/eas-update.yml
@@ -56,12 +56,15 @@ jobs:
         
         # Get base version and commit count
         LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+        echo "DEBUG: LAST_TAG='$LAST_TAG'"
         if [[ -n "$LAST_TAG" ]]; then
           BASE_VERSION=${LAST_TAG#v}
           COMMIT_COUNT=$(git rev-list --count ${LAST_TAG}..HEAD)
+          echo "DEBUG: Found tag $LAST_TAG, BASE_VERSION=$BASE_VERSION, COMMIT_COUNT=$COMMIT_COUNT"
         else
           BASE_VERSION="1.0.0"
           COMMIT_COUNT=$(git rev-list --count HEAD)
+          echo "DEBUG: No tags found, BASE_VERSION=$BASE_VERSION, COMMIT_COUNT=$COMMIT_COUNT"
         fi
         
         # Determine deployment based on trigger

--- a/.github/workflows/eas-update.yml
+++ b/.github/workflows/eas-update.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Fetch full git history for accurate commit counting
 
     - name: Setup Node.js
       uses: actions/setup-node@v4

--- a/.github/workflows/eas-update.yml
+++ b/.github/workflows/eas-update.yml
@@ -56,8 +56,8 @@ jobs:
         GIT_COMMIT=$(git rev-parse HEAD)
         echo "GIT_COMMIT=$GIT_COMMIT" >> $GITHUB_OUTPUT
         
-        # Get base version and commit count
-        LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+        # Get base version and commit count (only look for version tags)
+        LAST_TAG=$(git tag -l "v*.*.*" --sort=-version:refname | head -n1 || echo "")
         echo "DEBUG: LAST_TAG='$LAST_TAG'"
         if [[ -n "$LAST_TAG" ]]; then
           BASE_VERSION=${LAST_TAG#v}


### PR DESCRIPTION
## Summary
- Fixes the shallow clone issue causing incorrect commit counting in EAS workflow
- Should resolve `v1.0.0-beta.1` showing instead of `v1.0.0-beta.90+`

## Root Cause
GitHub Actions by default uses `fetch-depth: 1` (shallow clone) which only fetches the latest commit. This caused:
- `git rev-list --count HEAD` to return `1` instead of full commit history
- `git describe --tags` to fail finding tags (not fetched)
- Version showing as `v1.0.0-beta.1` instead of actual commit count

## Solution
- Add `fetch-depth: 0` to checkout step to fetch full git history
- Enables accurate commit counting and tag detection
- Includes debug output to verify the fix

## Expected Result
- **Before**: `v1.0.0-beta.1` (shallow clone, only 1 commit visible)
- **After**: `v1.0.0-beta.90+` (full history, correct commit count)

## References
- [Stack Overflow: Get commit count in GitHub Actions](https://stackoverflow.com/questions/72375995/how-to-get-commit-count-of-the-repository-in-github-actions)
- GitHub Actions checkout action defaults to shallow clone

## Test Plan
- [x] Workflow syntax is valid
- [ ] Deploy and verify version shows correct commit count
- [ ] Remove debug output once confirmed working

🤖 Generated with [Claude Code](https://claude.ai/code)