### PR TITLE
Enhance UI feedback and animations with conditional point display

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -43,7 +43,7 @@ jobs:
       run: npm run qualitycheck
 
     - name: Deploy with EAS
-      if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+      if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
       uses: ./.github/actions/eas-update
       with:
         expo-token: ${{ secrets.EXPO_TOKEN }}

--- a/__tests__/card-tracking/cardCountEquality.test.ts
+++ b/__tests__/card-tracking/cardCountEquality.test.ts
@@ -109,7 +109,7 @@ describe('Card Count Equality', () => {
     
     // Human should have won
     expect(trickResult.trickComplete).toBe(true);
-    expect(trickResult.trickWinner).toBe('You');
+    expect(trickResult.trickWinnerId).toBe('human');
     expect(state.currentPlayerIndex).toBe(0); // Human should be next
     
     const countsAfterTrick1 = state.players.map(p => p.hand.length);

--- a/__tests__/card-tracking/cardCountIntegration.test.ts
+++ b/__tests__/card-tracking/cardCountIntegration.test.ts
@@ -61,7 +61,7 @@ describe('Card Count Integration Test', () => {
       });
       
       if (result.trickComplete) {
-        console.log(`Trick complete! Winner: ${result.trickWinner}`);
+        console.log(`Trick complete! Winner: ${result.trickWinnerId}`);
       }
     }
     

--- a/__tests__/card-tracking/comprehensiveCardTracking.test.ts
+++ b/__tests__/card-tracking/comprehensiveCardTracking.test.ts
@@ -80,7 +80,7 @@ describe('Comprehensive Card Tracking Tests', () => {
         state = result.newState;
         
         if (result.trickComplete) {
-          console.log(`  Winner: ${result.trickWinner}`);
+          console.log(`  Winner: ${result.trickWinnerId}`);
           
           // Verify equal counts after trick
           if (!verifyCardCounts(state)) {
@@ -132,7 +132,7 @@ describe('Comprehensive Card Tracking Tests', () => {
           state = result.newState;
           
           if (result.trickComplete) {
-            console.log(`  Trick ${trickNum + 1} won by ${result.trickWinner}`);
+            console.log(`  Trick ${trickNum + 1} won by ${result.trickWinnerId}`);
           }
         }
         

--- a/__tests__/card-tracking/finalCardCountVerification.test.ts
+++ b/__tests__/card-tracking/finalCardCountVerification.test.ts
@@ -47,7 +47,7 @@ describe('Final Card Count Verification', () => {
         }
         
         if (result.trickComplete) {
-          console.log(`  Trick won by ${result.trickWinner}`);
+          console.log(`  Trick won by ${result.trickWinnerId}`);
         }
       }
       
@@ -122,13 +122,13 @@ describe('Final Card Count Verification', () => {
       state = result.newState;
       
       if (result.trickComplete) {
-        winners.push(result.trickWinner!);
-        console.log(`Trick winner: ${result.trickWinner}`);
-        console.log(`Next player should be: ${result.trickWinner}`);
+        winners.push(result.trickWinnerId!);
+        console.log(`Trick winner: ${result.trickWinnerId}`);
+        console.log(`Next player should be: ${result.trickWinnerId}`);
         console.log(`Next player is: ${state.players[state.currentPlayerIndex].name}`);
         
         // Verify winner is the next player
-        expect(state.players[state.currentPlayerIndex].name).toBe(result.trickWinner);
+        expect(state.players[state.currentPlayerIndex].id).toBe(result.trickWinnerId);
       }
     }
     

--- a/__tests__/card-tracking/humanMultiCardLoss.test.ts
+++ b/__tests__/card-tracking/humanMultiCardLoss.test.ts
@@ -26,7 +26,7 @@ describe('Human Multi-Card Loss Bug', () => {
       state = result.newState;
       
       if (result.trickComplete) {
-        console.log(`Winner: ${result.trickWinner}`);
+        console.log(`Winner: ${result.trickWinnerId}`);
       }
     }
     

--- a/__tests__/components/GameStatus.test.tsx
+++ b/__tests__/components/GameStatus.test.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import GameStatus from '../../src/components/GameStatus';
+import { GamePhase, Suit, Rank, Team } from '../../src/types';
+
+describe('GameStatus', () => {
+  const mockTeams: [Team, Team] = [
+    {
+      id: 'A',
+      currentRank: Rank.Two,
+      points: 0,
+      isDefending: true,
+    },
+    {
+      id: 'B',
+      currentRank: Rank.Two,
+      points: 25,
+      isDefending: false,
+    },
+  ];
+
+  const mockTrumpInfo = {
+    trumpRank: Rank.Two,
+    trumpSuit: Suit.Hearts,
+    declared: true,
+    declarerPlayerId: 'human',
+  };
+
+  it('should render team information correctly', () => {
+    const { getByText } = render(
+      <GameStatus
+        teams={mockTeams}
+        trumpInfo={mockTrumpInfo}
+        roundNumber={1}
+        gamePhase={GamePhase.Playing}
+      />
+    );
+
+    expect(getByText('Team A')).toBeTruthy();
+    expect(getByText('Team B')).toBeTruthy();
+    expect(getByText('Defending')).toBeTruthy();
+    expect(getByText('Attacking')).toBeTruthy();
+    expect(getByText('Round 1')).toBeTruthy();
+    expect(getByText('Playing')).toBeTruthy();
+  });
+
+  it('should show animated progress bar for attacking team', () => {
+    const { getByText, queryByText } = render(
+      <GameStatus
+        teams={mockTeams}
+        trumpInfo={mockTrumpInfo}
+        roundNumber={1}
+        gamePhase={GamePhase.Playing}
+      />
+    );
+
+    // Should show points for attacking team
+    expect(getByText('25/80')).toBeTruthy();
+    
+    // Defending team should not show points
+    const defendingTeamTexts = queryByText('0/80');
+    expect(defendingTeamTexts).toBeNull();
+  });
+
+  it('should handle teams with different point values', () => {
+    const teamsWithHighPoints: [Team, Team] = [
+      {
+        id: 'A',
+        currentRank: Rank.Three,
+        points: 0,
+        isDefending: true,
+      },
+      {
+        id: 'B',
+        currentRank: Rank.Three,
+        points: 65,
+        isDefending: false,
+      },
+    ];
+
+    const { getByText } = render(
+      <GameStatus
+        teams={teamsWithHighPoints}
+        trumpInfo={mockTrumpInfo}
+        roundNumber={2}
+        gamePhase={GamePhase.Scoring}
+      />
+    );
+
+    expect(getByText('65/80')).toBeTruthy();
+    expect(getByText('Round 2')).toBeTruthy();
+    expect(getByText('Scoring')).toBeTruthy();
+  });
+
+  it('should display trump information correctly', () => {
+    const { getByText, getAllByText } = render(
+      <GameStatus
+        teams={mockTeams}
+        trumpInfo={mockTrumpInfo}
+        roundNumber={1}
+        gamePhase={GamePhase.Playing}
+      />
+    );
+
+    expect(getByText('Trump')).toBeTruthy();
+    // There might be multiple "2" texts (from ranks), so check there's at least one
+    expect(getAllByText('2').length).toBeGreaterThan(0);
+    expect(getByText('♥')).toBeTruthy();
+  });
+
+  it('should handle no trump scenario', () => {
+    const noTrumpInfo = {
+      trumpRank: Rank.Ace,
+      trumpSuit: undefined,
+      declared: true,
+      declarerPlayerId: 'human',
+    };
+
+    const { getByText } = render(
+      <GameStatus
+        teams={mockTeams}
+        trumpInfo={noTrumpInfo}
+        roundNumber={1}
+        gamePhase={GamePhase.Playing}
+      />
+    );
+
+    expect(getByText('A')).toBeTruthy();
+    expect(getByText('🚫')).toBeTruthy();
+  });
+});

--- a/__tests__/components/TrickResultDisplay.test.tsx
+++ b/__tests__/components/TrickResultDisplay.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import TrickResultDisplay from '../../src/components/TrickResultDisplay';
+import { PlayerId, PlayerName } from '../../src/types';
+import { createGameState } from '../helpers';
+
+describe('TrickResultDisplay', () => {
+  it('should show points when attacking team wins', () => {
+    const gameState = createGameState();
+    // Set up attacking team (Team B) as non-defending
+    gameState.teams[1].isDefending = false;
+    gameState.players[1].team = 'B'; // Bot1 is on attacking team
+    
+    const { getByText } = render(
+      <TrickResultDisplay
+        visible={true}
+        winnerId={PlayerId.Bot1}
+        points={15}
+        gameState={gameState}
+      />
+    );
+
+    expect(getByText('Bot 1 wins!')).toBeTruthy();
+    expect(getByText('+15 pts')).toBeTruthy();
+  });
+
+  it('should NOT show points when defending team wins', () => {
+    const gameState = createGameState();
+    // Set up defending team (Team A) as defending
+    gameState.teams[0].isDefending = true;
+    gameState.players[0].team = 'A'; // Human is on defending team
+    
+    const { getByText, queryByText } = render(
+      <TrickResultDisplay
+        visible={true}
+        winnerId={PlayerId.Human}
+        points={15}
+        gameState={gameState}
+      />
+    );
+
+    expect(getByText('You win!')).toBeTruthy();
+    expect(queryByText('+15 pts')).toBeNull();
+  });
+
+  it('should show points when attacking team wins with zero points', () => {
+    const gameState = createGameState();
+    // Set up attacking team (Team B) as non-defending
+    gameState.teams[1].isDefending = false;
+    gameState.players[2].team = 'B'; // Bot2 is on attacking team
+    
+    const { getByText, queryByText } = render(
+      <TrickResultDisplay
+        visible={true}
+        winnerId={PlayerId.Bot2}
+        points={0}
+        gameState={gameState}
+      />
+    );
+
+    expect(getByText('Bot 2 wins!')).toBeTruthy();
+    expect(queryByText('+0 pts')).toBeNull(); // Zero points should not be shown
+  });
+
+  it('should not render when not visible', () => {
+    const gameState = createGameState();
+    
+    const { queryByText } = render(
+      <TrickResultDisplay
+        visible={false}
+        winnerId={PlayerId.Bot3}
+        points={10}
+        gameState={gameState}
+      />
+    );
+
+    expect(queryByText('Bot 3 wins!')).toBeNull();
+    expect(queryByText('+10 pts')).toBeNull();
+  });
+});

--- a/__tests__/game-flow/counterClockwiseRotation.test.ts
+++ b/__tests__/game-flow/counterClockwiseRotation.test.ts
@@ -38,7 +38,7 @@ describe('Counter-clockwise rotation', () => {
     
     // After trick completion, winner (Human with Ace) should be next
     expect(result4.trickComplete).toBe(true);
-    expect(result4.trickWinner).toBe('You');
+    expect(result4.trickWinnerId).toBe('human');
     expect(result4.newState.currentPlayerIndex).toBe(0); // Human won
   });
 

--- a/__tests__/game-flow/fullGameSimulation.test.ts
+++ b/__tests__/game-flow/fullGameSimulation.test.ts
@@ -86,7 +86,7 @@ describe('Full Game Simulation', () => {
             cardsBefore,
             cardsAfter,
             cardsPlayed: cardsToPlay.length,
-            winner: result.trickWinner,
+            winner: result.trickWinnerId,
             error
           });
           
@@ -120,7 +120,7 @@ describe('Full Game Simulation', () => {
           state = result.newState;
           
           if (result.trickComplete) {
-            trickWinner = result.trickWinner;
+            trickWinner = result.trickWinnerId;
           }
         }
         

--- a/__tests__/game-flow/humanWinsAndLeads.test.ts
+++ b/__tests__/game-flow/humanWinsAndLeads.test.ts
@@ -55,7 +55,7 @@ describe('Human Wins and Leads Bug', () => {
       state = result.newState;
       
       if (result.trickComplete) {
-        console.log(`\nTrick complete! Winner: ${result.trickWinner}`);
+        console.log(`\nTrick complete! Winner: ${result.trickWinnerId}`);
       }
     }
     

--- a/__tests__/game-flow/timingSynchronization.test.ts
+++ b/__tests__/game-flow/timingSynchronization.test.ts
@@ -45,7 +45,7 @@ describe('Timing Synchronization Tests', () => {
       logState(`After play ${play + 1}`, state);
       
       if (result.trickComplete) {
-        console.log(`Trick complete! Winner: ${result.trickWinner}`);
+        console.log(`Trick complete! Winner: ${result.trickWinnerId}`);
         logState('Trick complete', state);
         
         // Simulate what happens in the real game:

--- a/__tests__/game-state/winningPlayerIndexBug.test.ts
+++ b/__tests__/game-state/winningPlayerIndexBug.test.ts
@@ -24,16 +24,16 @@ describe('Trick Winner Determination', () => {
       
       if (result.trickComplete) {
         // Verify that the trick winner is properly determined
-        expect(result.trickWinner).toBeTruthy();
+        expect(result.trickWinnerId).toBeTruthy();
         
         // Verify that the current player index points to the winner
-        const expectedWinnerIndex = result.newState.players.findIndex(p => p.name === result.trickWinner);
+        const expectedWinnerIndex = result.newState.players.findIndex(p => p.id === result.trickWinnerId);
         expect(result.newState.currentPlayerIndex).toBe(expectedWinnerIndex);
         
         // Verify that currentTrick.winningPlayerId is set correctly
         expect(result.newState.currentTrick?.winningPlayerId).toBeTruthy();
         const winnerPlayer = result.newState.players.find(p => p.id === result.newState.currentTrick?.winningPlayerId);
-        expect(winnerPlayer?.name).toBe(result.trickWinner);
+        expect(winnerPlayer?.id).toBe(result.trickWinnerId);
       }
       
       state = result.newState;
@@ -61,12 +61,12 @@ describe('Trick Winner Determination', () => {
         
         if (result.trickComplete) {
           // The winner should be consistently identified
-          const winnerByName = result.newState.players.find(p => p.name === result.trickWinner);
-          const winnerById = result.newState.players.find(p => p.id === result.newState.currentTrick?.winningPlayerId);
+          const winnerById = result.newState.players.find(p => p.id === result.trickWinnerId);
+          const winnerByCurrentTrick = result.newState.players.find(p => p.id === result.newState.currentTrick?.winningPlayerId);
           
-          expect(winnerByName).toBeTruthy();
           expect(winnerById).toBeTruthy();
-          expect(winnerByName?.id).toBe(winnerById?.id);
+          expect(winnerByCurrentTrick).toBeTruthy();
+          expect(winnerById?.id).toBe(winnerByCurrentTrick?.id);
         }
         
         state = result.newState;

--- a/__tests__/game/doublePlayDetection.test.ts
+++ b/__tests__/game/doublePlayDetection.test.ts
@@ -101,7 +101,7 @@ describe('Double Play Detection Tests', () => {
         trickPlays++;
         
         if (result.trickComplete) {
-          console.log(`\nTrick complete! Winner: ${result.trickWinner}`);
+          console.log(`\nTrick complete! Winner: ${result.trickWinnerId}`);
           
           // Verify we played exactly 4 times
           if (trickPlays !== 4) {

--- a/__tests__/game/gamePlayManager.test.ts
+++ b/__tests__/game/gamePlayManager.test.ts
@@ -140,7 +140,7 @@ describe('gamePlayManager', () => {
       
       // Verify the trick is complete
       expect(result.trickComplete).toBe(true);
-      expect(result.trickWinner).toBe('Bot 1'); // ai1
+      expect(result.trickWinnerId).toBe(PlayerId.Bot1); // ai1
       expect(result.trickPoints).toBe(5); // 5 points from the Spades 5
       
       // Verify the trick was added to the tricks array

--- a/src/components/GameStatus.tsx
+++ b/src/components/GameStatus.tsx
@@ -9,6 +9,47 @@ interface GameStatusProps {
   gamePhase: GamePhase;
 }
 
+// Animated progress bar component
+const AnimatedProgressBar: React.FC<{
+  points: number;
+  maxPoints: number;
+}> = ({ points, maxPoints }) => {
+  const progressWidth = useRef(new Animated.Value(0)).current;
+  const previousPoints = useRef(0);
+
+  useEffect(() => {
+    const targetWidth = Math.min(100, (points / maxPoints) * 100);
+
+    // Calculate duration using the same logic as rolling number animation
+    const pointsDiff = Math.abs(points - previousPoints.current);
+    const duration = Math.min(1000, pointsDiff * 50); // Max 1 second, same as rolling number
+
+    Animated.timing(progressWidth, {
+      toValue: targetWidth,
+      duration: duration,
+      useNativeDriver: false, // Width animations require useNativeDriver: false
+    }).start();
+
+    previousPoints.current = points;
+  }, [points, maxPoints, progressWidth]);
+
+  const animatedStyle = {
+    width: progressWidth.interpolate({
+      inputRange: [0, 100],
+      outputRange: ["0%", "100%"],
+      extrapolate: "clamp",
+    }),
+  };
+
+  return (
+    <View style={styles.progressContainer}>
+      <Animated.View
+        style={[styles.progressBar, styles.attackingProgress, animatedStyle]}
+      />
+    </View>
+  );
+};
+
 // Rolling number animation component
 const RollingNumber: React.FC<{
   value: number;
@@ -203,17 +244,9 @@ const GameStatus: React.FC<GameStatusProps> = ({
               )}
             </View>
 
-            {/* Progress bar for points - only for attacking team */}
+            {/* Animated progress bar for points - only for attacking team */}
             {!team.isDefending && (
-              <View style={styles.progressContainer}>
-                <View
-                  style={[
-                    styles.progressBar,
-                    styles.attackingProgress,
-                    { width: `${Math.min(100, (team.points / 80) * 100)}%` },
-                  ]}
-                />
-              </View>
+              <AnimatedProgressBar points={team.points} maxPoints={80} />
             )}
           </View>
         ))}

--- a/src/components/TrickResultDisplay.tsx
+++ b/src/components/TrickResultDisplay.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import { StyleSheet, Text, View } from "react-native";
-import { PlayerName } from "../types";
+import { PlayerName, GameState } from "../types";
 
 interface TrickResultDisplayProps {
   visible: boolean;
-  winnerName: string;
+  winnerId: string;
   points: number;
+  gameState: GameState;
 }
 
 /**
@@ -13,18 +14,30 @@ interface TrickResultDisplayProps {
  */
 const TrickResultDisplay: React.FC<TrickResultDisplayProps> = ({
   visible,
-  winnerName,
+  winnerId,
   points,
+  gameState,
 }) => {
   // Just use the visible prop directly - simpler code
   if (!visible) return null;
+
+  // Find the winning player and determine team info
+  const winningPlayer = gameState.players.find((p) => p.id === winnerId);
+  if (!winningPlayer) return null;
+
+  const winningTeam = gameState.teams.find((t) => t.id === winningPlayer.team);
+  const isAttackingTeamWin = winningTeam ? !winningTeam.isDefending : false;
+
+  const winnerName = winningPlayer.name;
 
   return (
     <View style={styles.container}>
       <Text style={styles.winnerText}>
         {winnerName === PlayerName.Human ? "You win!" : `${winnerName} wins!`}
       </Text>
-      {points > 0 && <Text style={styles.pointsText}>+{points} pts</Text>}
+      {points > 0 && isAttackingTeamWin && (
+        <Text style={styles.pointsText}>+{points} pts</Text>
+      )}
     </View>
   );
 };

--- a/src/game/gamePlayManager.ts
+++ b/src/game/gamePlayManager.ts
@@ -14,7 +14,7 @@ export function processPlay(
 ): {
   newState: GameState;
   trickComplete: boolean;
-  trickWinner?: string;
+  trickWinnerId?: string;
   trickPoints?: number;
   completedTrick?: Trick;
 } {
@@ -147,16 +147,13 @@ export function processPlay(
     // Only then will we use the saved completedTrick for displaying the result
     // newState.currentTrick = null; -- REMOVED THIS LINE
 
-    // Return trick completion info with winning player name
-    const resultWinningPlayer = newState.players[winningPlayerIndex];
-
     // Use the completed trick with winner ID for result display
     const trickWithWinner = completedTrick;
 
     return {
       newState,
       trickComplete: true,
-      trickWinner: resultWinningPlayer?.name || "Unknown Player",
+      trickWinnerId: winningPlayerId,
       trickPoints: completedTrick.points,
       completedTrick: trickWithWinner,
     };

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -17,7 +17,7 @@ import {
 
 // Interface for trick completion data
 interface TrickCompletionData {
-  winnerName: string;
+  winnerId: string;
   points: number;
   completedTrick: any; // Using any to avoid circular dependencies
   timestamp: number;
@@ -147,7 +147,7 @@ export function useGameState() {
     const result = processPlay(gameState, cards);
 
     // For trick complete scenario, we need to handle things in a specific order
-    if (result.trickComplete && result.trickWinner && result.completedTrick) {
+    if (result.trickComplete && result.trickWinnerId && result.completedTrick) {
       // Trick completed - winner and points recorded
 
       // IMPORTANT: Store trick data in ref BEFORE updating state
@@ -157,7 +157,7 @@ export function useGameState() {
         // IMPORTANT: A completed trick has leadingCombo (first play) + plays (follow plays)
         // For a 4-player game, the plays array should have exactly 3 entries when complete
         trickCompletionDataRef.current = {
-          winnerName: result.trickWinner,
+          winnerId: result.trickWinnerId,
           points: result.trickPoints || 0,
           completedTrick: {
             ...result.completedTrick,

--- a/src/hooks/useTrickResults.ts
+++ b/src/hooks/useTrickResults.ts
@@ -11,7 +11,7 @@ import {
  */
 export function useTrickResults() {
   const [showTrickResult, setShowTrickResult] = useState(false);
-  const [lastTrickWinner, setLastTrickWinner] = useState("");
+  const [lastTrickWinnerId, setLastTrickWinnerId] = useState("");
   const [lastTrickPoints, setLastTrickPoints] = useState(0);
   const [lastCompletedTrick, setLastCompletedTrick] = useState<
     (Trick & { winningPlayerId?: string }) | null
@@ -78,19 +78,19 @@ export function useTrickResults() {
     return () => {
       if (timer) clearTimeout(timer);
     };
-  }, [showTrickResult, lastTrickWinner, lastTrickPoints]);
+  }, [showTrickResult, lastTrickWinnerId, lastTrickPoints]);
 
   // Safety timers have been removed as they might hide underlying issues
   // instead of fixing the root causes
 
   // Handle a completed trick - simplified to just show result
   const handleTrickCompletion = (
-    winnerName: string,
+    winnerId: string,
     points: number,
     trick: Trick & { winningPlayerId?: string },
   ) => {
     // Store values for the trick result
-    setLastTrickWinner(winnerName);
+    setLastTrickWinnerId(winnerId);
     setLastTrickPoints(points);
 
     // Mark that we're transitioning between tricks
@@ -107,7 +107,7 @@ export function useTrickResults() {
 
   return {
     showTrickResult,
-    lastTrickWinner,
+    lastTrickWinnerId,
     lastTrickPoints,
     lastCompletedTrick,
     isTransitioningTricks,

--- a/src/screens/GameScreenController.tsx
+++ b/src/screens/GameScreenController.tsx
@@ -47,7 +47,7 @@ const GameScreenController: React.FC = () => {
   // Trick results management
   const {
     showTrickResult,
-    lastTrickWinner,
+    lastTrickWinnerId,
     lastTrickPoints,
     lastCompletedTrick,
     isTransitioningTricks,
@@ -115,7 +115,7 @@ const GameScreenController: React.FC = () => {
       trickCompletionDataRef.current.timestamp >
       lastProcessedTrickTimestampRef.current
     ) {
-      const { winnerName, points, completedTrick, timestamp } =
+      const { winnerId, points, completedTrick, timestamp } =
         trickCompletionDataRef.current;
       // Detected completed trick
 
@@ -134,7 +134,7 @@ const GameScreenController: React.FC = () => {
         setLastCompletedTrick(completedTrick);
 
         // 2. Now show the trick result
-        handleTrickCompletion(winnerName, points, completedTrick);
+        handleTrickCompletion(winnerId, points, completedTrick);
 
         // No extra defensive timers needed anymore - keeping it simple
       }
@@ -168,7 +168,7 @@ const GameScreenController: React.FC = () => {
       waitingForAI={waitingForAI}
       waitingPlayerId={waitingPlayerId}
       showTrickResult={showTrickResult}
-      lastTrickWinner={lastTrickWinner}
+      lastTrickWinnerId={lastTrickWinnerId}
       lastTrickPoints={lastTrickPoints}
       lastCompletedTrick={lastCompletedTrick}
       showRoundComplete={showRoundComplete}

--- a/src/screens/GameScreenView.tsx
+++ b/src/screens/GameScreenView.tsx
@@ -33,7 +33,7 @@ interface GameScreenViewProps {
   waitingForAI: boolean;
   waitingPlayerId: string;
   showTrickResult: boolean;
-  lastTrickWinner: string;
+  lastTrickWinnerId: string;
   lastTrickPoints: number;
   lastCompletedTrick: (Trick & { winningPlayerId?: string }) | null;
   showRoundComplete: boolean;
@@ -78,7 +78,7 @@ const GameScreenView: React.FC<GameScreenViewProps> = ({
   waitingForAI,
   waitingPlayerId,
   showTrickResult,
-  lastTrickWinner,
+  lastTrickWinnerId,
   lastTrickPoints,
   lastCompletedTrick,
   showRoundComplete,
@@ -321,8 +321,9 @@ const GameScreenView: React.FC<GameScreenViewProps> = ({
             trickResult={
               <TrickResultDisplay
                 visible={showTrickResult}
-                winnerName={lastTrickWinner}
+                winnerId={lastTrickWinnerId}
                 points={lastTrickPoints}
+                gameState={gameState}
               />
             }
           />


### PR DESCRIPTION
## Summary
• Add conditional point display in trick results - only show "+x pts" when attacking team wins
• Implement animated progress bar in attacking team status box with synchronized timing
• Refactor from winnerName to winnerId for better component encapsulation
• Remove pull request triggers from EAS deployment workflow for efficiency

## Test plan
- [x] All 324 tests passing
- [x] Quality checks (lint, typecheck) passing
- [x] Point display only appears for attacking team wins
- [x] Progress bar animation synchronized with rolling number timing
- [x] Workflow optimization verified

🤖 Generated with [Claude Code](https://claude.ai/code)