### PR TITLE
Fix tractor following rules and AI validation logic (issue #71)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,6 +347,7 @@ enum ComboStrength {
 - **Use type-safe test utilities**: Never use magic strings in test assertions
 - **Jest mock limitations**: Only mock what needs to be controlled for the specific test
 - **Test realism**: Use actual game logic when possible for more realistic test coverage
+- **Jest debugging**: Use `silent: true|false` in `jest.config.js` to control console output during test debugging
 
 **✅ Correct Test Enum Usage:**
 ```typescript

--- a/__tests__/ai/aiTractorFollowing.test.ts
+++ b/__tests__/ai/aiTractorFollowing.test.ts
@@ -1,0 +1,154 @@
+import { 
+  initializeGame, 
+  isValidPlay
+} from '../../src/game/gameLogic';
+import { getAIMove } from '../../src/ai/aiLogic';
+import { PlayerId, GamePhase, Suit, Rank } from '../../src/types';
+import { createCard } from '../helpers/cards';
+
+/**
+ * This test verifies the fix for issue #71 - AI tractor following rules.
+ * AI should now properly follow tractor hierarchy: tractors -> pairs -> singles
+ */
+describe('Issue #71: AI Tractor Following Rules', () => {
+  test('AI plays valid moves when following trump tractors', () => {
+    console.log('\n✅ VERIFYING FIX FOR ISSUE #71: AI TRACTOR FOLLOWING');
+    
+    // Initialize game with Hearts as trump (rank 2)
+    let gameState = initializeGame();
+    gameState.gamePhase = GamePhase.Playing;
+    gameState.trumpInfo = {
+      trumpSuit: Suit.Hearts,
+      trumpRank: Rank.Two,
+      declared: true,
+      declarerPlayerId: PlayerId.Human
+    };
+    
+    // Find players
+    const bot1Player = gameState.players.find(p => p.id === PlayerId.Bot1)!;
+    
+    // Bot1 has trump cards that could form pairs
+    bot1Player.hand = [
+      createCard(Suit.Hearts, Rank.Seven), createCard(Suit.Hearts, Rank.Seven), // Hearts pair (trump suit)
+      createCard(Suit.Hearts, Rank.Eight), createCard(Suit.Hearts, Rank.Eight), // Hearts pair (trump suit)
+      createCard(Suit.Hearts, Rank.Nine), // Single trump
+      createCard(Suit.Spades, Rank.Two), createCard(Suit.Spades, Rank.Two), // Trump rank pair in other suit
+      createCard(Suit.Clubs, Rank.Ten)
+    ];
+    
+    // Human leads with Hearts tractor (trump suit tractor)
+    const leadingTractor = [
+      createCard(Suit.Hearts, Rank.Five), createCard(Suit.Hearts, Rank.Five),
+      createCard(Suit.Hearts, Rank.Six), createCard(Suit.Hearts, Rank.Six)
+    ];
+    
+    gameState.currentTrick = {
+      leadingCombo: leadingTractor,
+      plays: [],
+      leadingPlayerId: PlayerId.Human,
+      points: 10
+    };
+    gameState.currentPlayerIndex = 1; // Bot1 is at index 1
+    
+    console.log('Human led Hearts tractor: 5♥-5♥-6♥-6♥ (trump suit tractor)');
+    console.log('Bot1 hand:');
+    bot1Player.hand.forEach(card => {
+      console.log(`  ${card.suit}-${card.rank}`);
+    });
+    console.log('Bot1 has Hearts pairs: 7♥-7♥ and 8♥-8♥ available');
+    
+    // Get AI move - should now be valid
+    const aiMove = getAIMove(gameState, PlayerId.Bot1);
+    console.log('AI move:', aiMove.map(card => `${card.suit}-${card.rank}`));
+    
+    // Check if the move is valid
+    const isValid = isValidPlay(aiMove, leadingTractor, bot1Player.hand, gameState.trumpInfo);
+    console.log('Is AI move valid?', isValid);
+    
+    if (isValid) {
+      console.log('✅ FIX CONFIRMED: AI now generates VALID moves!');
+      
+      // Check if AI properly used pairs instead of singles
+      const hasHeartsPairs = (
+        aiMove.filter(card => card.suit === Suit.Hearts).length === 4 &&
+        aiMove.filter(card => card.rank === Rank.Seven && card.suit === Suit.Hearts).length === 2 &&
+        aiMove.filter(card => card.rank === Rank.Eight && card.suit === Suit.Hearts).length === 2
+      );
+      
+      if (hasHeartsPairs) {
+        console.log('✅ PERFECT: AI properly played Hearts pairs [7♥, 7♥, 8♥, 8♥] as expected!');
+      } else {
+        console.log('⚠️  AI played valid but suboptimal move - might be using trump rank pairs or other valid combination');
+      }
+    } else {
+      console.log('❌ REGRESSION: AI is still generating invalid moves!');
+    }
+    
+    // The fix should make AI moves valid
+    expect(isValid).toBe(true); // AI move should now be valid!
+    expect(aiMove.length).toBe(4); // AI returns correct length
+    
+    // Additional verification: AI should prioritize trump suit pairs when available
+    const trumpSuitCards = aiMove.filter(card => card.suit === Suit.Hearts);
+    expect(trumpSuitCards.length).toBeGreaterThan(0); // Should use some trump suit cards
+  });
+  
+  test('AI follows proper hierarchy: tractors > pairs > singles', () => {
+    console.log('\n🎯 TESTING AI HIERARCHY: Tractors > Pairs > Singles');
+    
+    let gameState = initializeGame();
+    gameState.gamePhase = GamePhase.Playing;
+    gameState.trumpInfo = {
+      trumpSuit: Suit.Hearts,
+      trumpRank: Rank.Two,
+      declared: true,
+      declarerPlayerId: PlayerId.Human
+    };
+    
+    const bot1Player = gameState.players.find(p => p.id === PlayerId.Bot1)!;
+    
+    // Bot1 has a trump tractor available
+    bot1Player.hand = [
+      createCard(Suit.Hearts, Rank.Seven), createCard(Suit.Hearts, Rank.Seven), // Hearts pair
+      createCard(Suit.Hearts, Rank.Eight), createCard(Suit.Hearts, Rank.Eight), // Hearts pair (consecutive = tractor!)
+      createCard(Suit.Hearts, Rank.Nine), createCard(Suit.Hearts, Rank.Ten), // Singles
+      createCard(Suit.Clubs, Rank.King)
+    ];
+    
+    // Human leads with non-trump tractor
+    const leadingTractor = [
+      createCard(Suit.Spades, Rank.Five), createCard(Suit.Spades, Rank.Five),
+      createCard(Suit.Spades, Rank.Six), createCard(Suit.Spades, Rank.Six)
+    ];
+    
+    gameState.currentTrick = {
+      leadingCombo: leadingTractor,
+      plays: [],
+      leadingPlayerId: PlayerId.Human,
+      points: 10
+    };
+    gameState.currentPlayerIndex = 1; // Bot1 is at index 1
+    
+    console.log('Human led Spades tractor (non-trump), AI has Hearts tractor available');
+    
+    const aiMove = getAIMove(gameState, PlayerId.Bot1);
+    console.log('AI move:', aiMove.map(card => `${card.suit}-${card.rank}`));
+    
+    const isValid = isValidPlay(aiMove, leadingTractor, bot1Player.hand, gameState.trumpInfo);
+    console.log('Is AI move valid?', isValid);
+    
+    // AI should play the trump tractor if possible (7♥-7♥-8♥-8♥)
+    const isTrumpTractor = (
+      aiMove.length === 4 &&
+      aiMove.filter(card => card.rank === Rank.Seven && card.suit === Suit.Hearts).length === 2 &&
+      aiMove.filter(card => card.rank === Rank.Eight && card.suit === Suit.Hearts).length === 2
+    );
+    
+    if (isTrumpTractor) {
+      console.log('🎯 EXCELLENT: AI prioritized trump tractor over other options!');
+    }
+    
+    expect(isValid).toBe(true);
+    expect(aiMove.length).toBe(4);
+  });
+});

--- a/__tests__/game/tractorFollowingRules.test.ts
+++ b/__tests__/game/tractorFollowingRules.test.ts
@@ -1,0 +1,336 @@
+import { Card, GameState, Player, Rank, Suit, Team, Trick, PlayerId, PlayerName, GamePhase, ComboType, TrumpInfo } from "../../src/types";
+import { isValidPlay, identifyCombos } from '../../src/game/gameLogic';
+
+/**
+ * Tests for tractor following rules (Issue #71)
+ * 
+ * When a tractor is led, players must follow this sequence:
+ * 1. Must play tractor in the same suit if available  
+ * 2. Must play same number of pairs as leading tractor if available
+ * 3. Must use all pairs in the same suit if available
+ * 4. Use singles in the same suit, when no enough pairs
+ * 5. Other small cards from other suits when run out same suit
+ * 
+ * Trump tractor following: same rules apply, but all trump suit pairs,
+ * trump rank pairs, and joker pairs count as pairs.
+ */
+
+describe('Tractor Following Rules (Issue #71)', () => {
+  let mockState: GameState;
+  let humanPlayer: Player;
+  let cardId = 0;
+  
+  const createCard = (suit: Suit, rank: Rank): Card => ({
+    id: `card-${cardId++}`,
+    suit,
+    rank,
+    points: rank === Rank.King || rank === Rank.Ten ? 10 : rank === Rank.Five ? 5 : 0
+  });
+  
+  beforeEach(() => {
+    cardId = 0;
+    
+    humanPlayer = {
+      id: PlayerId.Human,
+      name: PlayerName.Human,
+      hand: [],
+      isHuman: true,
+      team: 'A',
+    };
+    
+    const ai1: Player = {
+      id: PlayerId.Bot1,
+      name: PlayerName.Bot1,
+      hand: [],
+      isHuman: false,
+      team: 'B',
+    };
+    
+    mockState = {
+      players: [humanPlayer, ai1],
+      teams: [
+        { id: 'A', currentRank: Rank.Two, points: 0, isDefending: true },
+        { id: 'B', currentRank: Rank.Two, points: 0, isDefending: false }
+      ],
+      deck: [],
+      kittyCards: [],
+      currentTrick: null,
+      trumpInfo: { trumpRank: Rank.Two, declared: true, trumpSuit: Suit.Spades },
+      tricks: [],
+      roundNumber: 1,
+      currentPlayerIndex: 0,
+      gamePhase: GamePhase.Playing
+    };
+  });
+  
+  describe('Rule 1: Must play tractor in same suit if available', () => {
+    test('Should enforce tractor following when player has matching tractor', () => {
+      // AI leads with hearts tractor: 9-9-10-10  
+      const leadingTractor: Card[] = [
+        createCard(Suit.Hearts, Rank.Nine),
+        createCard(Suit.Hearts, Rank.Nine),
+        createCard(Suit.Hearts, Rank.Ten),
+        createCard(Suit.Hearts, Rank.Ten)
+      ];
+      
+      mockState.currentTrick = {
+        leadingCombo: leadingTractor,
+        plays: [],
+        leadingPlayerId: 'ai1',
+        points: 20
+      };
+      
+      // Human has hearts tractor: J-J-Q-Q and other cards
+      const heartJack1 = createCard(Suit.Hearts, Rank.Jack);
+      const heartJack2 = createCard(Suit.Hearts, Rank.Jack);
+      const heartQueen1 = createCard(Suit.Hearts, Rank.Queen);
+      const heartQueen2 = createCard(Suit.Hearts, Rank.Queen);
+      const heartKing = createCard(Suit.Hearts, Rank.King);
+      const spadeAce = createCard(Suit.Spades, Rank.Ace);
+      
+      humanPlayer.hand = [heartJack1, heartJack2, heartQueen1, heartQueen2, heartKing, spadeAce];
+      
+      // Must play the hearts tractor
+      const validTractorPlay = [heartJack1, heartJack2, heartQueen1, heartQueen2];
+      const invalidSinglesPlay = [heartKing, heartJack1, heartQueen1, spadeAce]; // 4 singles instead of tractor
+      
+      const validResult = isValidPlay(validTractorPlay, leadingTractor, humanPlayer.hand, mockState.trumpInfo);
+      const invalidResult = isValidPlay(invalidSinglesPlay, leadingTractor, humanPlayer.hand, mockState.trumpInfo);
+      
+      expect(validResult).toBe(true);
+      expect(invalidResult).toBe(false); // Should fail - must use tractor when available
+    });
+  });
+  
+  describe('Rule 2: Must play same number of pairs when no tractor available', () => {
+    test('Should enforce pair following when player has pairs but no tractor', () => {
+      // AI leads with hearts tractor: 9-9-10-10 (2 pairs)
+      const leadingTractor: Card[] = [
+        createCard(Suit.Hearts, Rank.Nine),
+        createCard(Suit.Hearts, Rank.Nine),
+        createCard(Suit.Hearts, Rank.Ten),
+        createCard(Suit.Hearts, Rank.Ten)
+      ];
+      
+      mockState.currentTrick = {
+        leadingCombo: leadingTractor,
+        plays: [],
+        leadingPlayerId: 'ai1',
+        points: 20
+      };
+      
+      // Human has 2 non-consecutive pairs in hearts (no tractor) + other cards
+      const heartJack1 = createCard(Suit.Hearts, Rank.Jack);
+      const heartJack2 = createCard(Suit.Hearts, Rank.Jack);
+      const heartKing1 = createCard(Suit.Hearts, Rank.King);
+      const heartKing2 = createCard(Suit.Hearts, Rank.King);
+      const heartAce = createCard(Suit.Hearts, Rank.Ace);
+      const spadeTwo = createCard(Suit.Spades, Rank.Two);
+      
+      humanPlayer.hand = [heartJack1, heartJack2, heartKing1, heartKing2, heartAce, spadeTwo];
+      
+      // Must play 2 pairs (same number as tractor), not singles
+      const validPairsPlay = [heartJack1, heartJack2, heartKing1, heartKing2];
+      const invalidSinglesPlay = [heartJack1, heartKing1, heartAce, spadeTwo]; // 4 singles instead of pairs
+      
+      const validResult = isValidPlay(validPairsPlay, leadingTractor, humanPlayer.hand, mockState.trumpInfo);
+      const invalidResult = isValidPlay(invalidSinglesPlay, leadingTractor, humanPlayer.hand, mockState.trumpInfo);
+      
+      expect(validResult).toBe(true);
+      expect(invalidResult).toBe(false); // Should fail - must use pairs when available
+    });
+  });
+  
+  describe('Rule 3: Must use all pairs in same suit if available', () => {
+    test('Should enforce using all available pairs in suit', () => {
+      // AI leads with hearts tractor: 9-9-10-10 (2 pairs)
+      const leadingTractor: Card[] = [
+        createCard(Suit.Hearts, Rank.Nine),
+        createCard(Suit.Hearts, Rank.Nine),
+        createCard(Suit.Hearts, Rank.Ten),
+        createCard(Suit.Hearts, Rank.Ten)
+      ];
+      
+      mockState.currentTrick = {
+        leadingCombo: leadingTractor,
+        plays: [],
+        leadingPlayerId: 'ai1',
+        points: 20
+      };
+      
+      // Human has 3 pairs in hearts but tractor only needs 2 pairs
+      const heartJack1 = createCard(Suit.Hearts, Rank.Jack);
+      const heartJack2 = createCard(Suit.Hearts, Rank.Jack);
+      const heartQueen1 = createCard(Suit.Hearts, Rank.Queen);
+      const heartQueen2 = createCard(Suit.Hearts, Rank.Queen);
+      const heartKing1 = createCard(Suit.Hearts, Rank.King);
+      const heartKing2 = createCard(Suit.Hearts, Rank.King);
+      const spadeAce = createCard(Suit.Spades, Rank.Ace);
+      
+      humanPlayer.hand = [heartJack1, heartJack2, heartQueen1, heartQueen2, heartKing1, heartKing2, spadeAce];
+      
+      // Should be able to choose any 2 pairs from the 3 available
+      const validPlay1 = [heartJack1, heartJack2, heartQueen1, heartQueen2];
+      const validPlay2 = [heartQueen1, heartQueen2, heartKing1, heartKing2];
+      const invalidPlay = [heartJack1, heartQueen1, heartKing1, spadeAce]; // Singles instead of pairs
+      
+      const validResult1 = isValidPlay(validPlay1, leadingTractor, humanPlayer.hand, mockState.trumpInfo);
+      const validResult2 = isValidPlay(validPlay2, leadingTractor, humanPlayer.hand, mockState.trumpInfo);
+      const invalidResult = isValidPlay(invalidPlay, leadingTractor, humanPlayer.hand, mockState.trumpInfo);
+      
+      expect(validResult1).toBe(true);
+      expect(validResult2).toBe(true);
+      expect(invalidResult).toBe(false); // Should fail - must use pairs when available
+    });
+  });
+  
+  describe('Rule 4: Use singles when no enough pairs', () => {
+    test('Should allow singles when player has insufficient pairs', () => {
+      // AI leads with hearts tractor: 9-9-10-10 (2 pairs = 4 cards)
+      const leadingTractor: Card[] = [
+        createCard(Suit.Hearts, Rank.Nine),
+        createCard(Suit.Hearts, Rank.Nine),
+        createCard(Suit.Hearts, Rank.Ten),
+        createCard(Suit.Hearts, Rank.Ten)
+      ];
+      
+      mockState.currentTrick = {
+        leadingCombo: leadingTractor,
+        plays: [],
+        leadingPlayerId: 'ai1',
+        points: 20
+      };
+      
+      // Human has only 1 pair in hearts + singles
+      const heartJack1 = createCard(Suit.Hearts, Rank.Jack);
+      const heartJack2 = createCard(Suit.Hearts, Rank.Jack);
+      const heartQueen = createCard(Suit.Hearts, Rank.Queen);
+      const heartKing = createCard(Suit.Hearts, Rank.King);
+      const spadeAce = createCard(Suit.Spades, Rank.Ace);
+      
+      humanPlayer.hand = [heartJack1, heartJack2, heartQueen, heartKing, spadeAce];
+      
+      // Must use the available pair + singles from same suit, then other suits
+      const validPlay = [heartJack1, heartJack2, heartQueen, heartKing]; // 1 pair + 2 singles from hearts
+      const invalidPlay = [heartJack1, heartQueen, spadeAce, heartKing]; // Not using the pair
+      
+      const validResult = isValidPlay(validPlay, leadingTractor, humanPlayer.hand, mockState.trumpInfo);
+      const invalidResult = isValidPlay(invalidPlay, leadingTractor, humanPlayer.hand, mockState.trumpInfo);
+      
+      expect(validResult).toBe(true);
+      expect(invalidResult).toBe(false); // Should fail - must use available pairs
+    });
+  });
+  
+  describe('Rule 5: Other cards when run out of same suit', () => {
+    test('Should allow any cards when no cards of leading suit', () => {
+      // AI leads with hearts tractor: 9-9-10-10
+      const leadingTractor: Card[] = [
+        createCard(Suit.Hearts, Rank.Nine),
+        createCard(Suit.Hearts, Rank.Nine),
+        createCard(Suit.Hearts, Rank.Ten),
+        createCard(Suit.Hearts, Rank.Ten)
+      ];
+      
+      mockState.currentTrick = {
+        leadingCombo: leadingTractor,
+        plays: [],
+        leadingPlayerId: 'ai1',
+        points: 20
+      };
+      
+      // Human has no hearts - only other suits
+      const spadeAce = createCard(Suit.Spades, Rank.Ace);
+      const clubKing = createCard(Suit.Clubs, Rank.King);
+      const diamondQueen = createCard(Suit.Diamonds, Rank.Queen);
+      const clubJack = createCard(Suit.Clubs, Rank.Jack);
+      
+      humanPlayer.hand = [spadeAce, clubKing, diamondQueen, clubJack];
+      
+      // Can play any 4 cards
+      const anyCardsPlay = [spadeAce, clubKing, diamondQueen, clubJack];
+      
+      const result = isValidPlay(anyCardsPlay, leadingTractor, humanPlayer.hand, mockState.trumpInfo);
+      
+      expect(result).toBe(true); // Should be valid - no hearts available
+    });
+  });
+  
+  describe('Trump Tractor Following Rules', () => {
+    test('Should treat trump rank pairs as valid pairs when following trump tractor', () => {
+      // Create trump info where 2 is trump rank and spades is trump suit
+      const trumpInfo: TrumpInfo = { trumpRank: Rank.Two, declared: true, trumpSuit: Suit.Spades };
+      
+      // AI leads with trump tractor (spades): 3-3-4-4
+      const leadingTrumpTractor: Card[] = [
+        createCard(Suit.Spades, Rank.Three),
+        createCard(Suit.Spades, Rank.Three),
+        createCard(Suit.Spades, Rank.Four),
+        createCard(Suit.Spades, Rank.Four)
+      ];
+      
+      mockState.currentTrick = {
+        leadingCombo: leadingTrumpTractor,
+        plays: [],
+        leadingPlayerId: 'ai1',
+        points: 0
+      };
+      mockState.trumpInfo = trumpInfo;
+      
+      // Human has trump rank pairs (2s) in different suits - these count as trump pairs
+      const hearts2_1 = createCard(Suit.Hearts, Rank.Two);
+      const hearts2_2 = createCard(Suit.Hearts, Rank.Two);
+      const clubs2_1 = createCard(Suit.Clubs, Rank.Two);
+      const clubs2_2 = createCard(Suit.Clubs, Rank.Two);
+      const spadeAce = createCard(Suit.Spades, Rank.Ace);
+      
+      humanPlayer.hand = [hearts2_1, hearts2_2, clubs2_1, clubs2_2, spadeAce];
+      
+      // Should be able to use trump rank pairs as valid pairs
+      const validTrumpPairsPlay = [hearts2_1, hearts2_2, clubs2_1, clubs2_2];
+      
+      const result = isValidPlay(validTrumpPairsPlay, leadingTrumpTractor, humanPlayer.hand, trumpInfo);
+      
+      expect(result).toBe(true); // Should be valid - trump rank pairs count as pairs
+    });
+  });
+  
+  describe('Current Implementation Status', () => {
+    test('GOOD: Current implementation correctly rejects singles when pairs available', () => {
+      // This test shows the current implementation is working correctly
+      
+      // AI leads with hearts tractor: 9-9-10-10
+      const leadingTractor: Card[] = [
+        createCard(Suit.Hearts, Rank.Nine),
+        createCard(Suit.Hearts, Rank.Nine),
+        createCard(Suit.Hearts, Rank.Ten),
+        createCard(Suit.Hearts, Rank.Ten)
+      ];
+      
+      mockState.currentTrick = {
+        leadingCombo: leadingTractor,
+        plays: [],
+        leadingPlayerId: 'ai1',
+        points: 20
+      };
+      
+      // Human has pairs available
+      const heartJack1 = createCard(Suit.Hearts, Rank.Jack);
+      const heartJack2 = createCard(Suit.Hearts, Rank.Jack);
+      const heartQueen1 = createCard(Suit.Hearts, Rank.Queen);
+      const heartQueen2 = createCard(Suit.Hearts, Rank.Queen);
+      const heartKing = createCard(Suit.Hearts, Rank.King);
+      const heartAce = createCard(Suit.Hearts, Rank.Ace);
+      
+      humanPlayer.hand = [heartJack1, heartJack2, heartQueen1, heartQueen2, heartKing, heartAce];
+      
+      // This should be invalid and current implementation correctly rejects it
+      const invalidSinglesPlay = [heartJack1, heartQueen1, heartKing, heartAce]; // 4 singles
+      
+      const result = isValidPlay(invalidSinglesPlay, leadingTractor, humanPlayer.hand, mockState.trumpInfo);
+      
+      // Current implementation correctly rejects this
+      expect(result).toBe(false); // CORRECT - must use pairs when available
+    });
+  });
+});

--- a/__tests__/game/trumpTractorFollowingDetailedTest.test.ts
+++ b/__tests__/game/trumpTractorFollowingDetailedTest.test.ts
@@ -1,0 +1,324 @@
+import { Card, GameState, Player, Rank, Suit, Team, Trick, PlayerId, PlayerName, GamePhase, ComboType, TrumpInfo, JokerType } from "../../src/types";
+import { isValidPlay, identifyCombos, isTrump } from '../../src/game/gameLogic';
+
+/**
+ * Detailed tests for trump tractor following rules mentioned in Issue #71
+ * 
+ * Focus on the trump-specific rule: "When following tractor in trumps, same rule applies, 
+ * besides all trump suit pairs, trump rank pairs, joke pairs are all counted as pairs."
+ */
+
+describe('Trump Tractor Following Detailed Rules (Issue #71)', () => {
+  let mockState: GameState;
+  let humanPlayer: Player;
+  let cardId = 0;
+  
+  const createCard = (suit: Suit, rank: Rank): Card => ({
+    id: `card-${cardId++}`,
+    suit,
+    rank,
+    points: rank === Rank.King || rank === Rank.Ten ? 10 : rank === Rank.Five ? 5 : 0
+  });
+  
+  const createJoker = (jokerType: JokerType): Card => ({
+    id: `joker-${cardId++}`,
+    joker: jokerType,
+    points: 0
+  });
+  
+  beforeEach(() => {
+    cardId = 0;
+    
+    humanPlayer = {
+      id: PlayerId.Human,
+      name: PlayerName.Human,
+      hand: [],
+      isHuman: true,
+      team: 'A',
+    };
+    
+    const ai1: Player = {
+      id: PlayerId.Bot1,
+      name: PlayerName.Bot1,
+      hand: [],
+      isHuman: false,
+      team: 'B',
+    };
+    
+    mockState = {
+      players: [humanPlayer, ai1],
+      teams: [
+        { id: 'A', currentRank: Rank.Two, points: 0, isDefending: true },
+        { id: 'B', currentRank: Rank.Two, points: 0, isDefending: false }
+      ],
+      deck: [],
+      kittyCards: [],
+      currentTrick: null,
+      trumpInfo: { trumpRank: Rank.Two, declared: true, trumpSuit: Suit.Spades },
+      tricks: [],
+      roundNumber: 1,
+      currentPlayerIndex: 0,
+      gamePhase: GamePhase.Playing
+    };
+  });
+  
+  describe('Trump Suit Pairs Count as Valid Pairs', () => {
+    test('Should accept trump suit pairs when following trump tractor', () => {
+      // Trump is 2 with spades as trump suit
+      const trumpInfo: TrumpInfo = { trumpRank: Rank.Two, declared: true, trumpSuit: Suit.Spades };
+      
+      // AI leads with spades trump tractor: 3-3-4-4
+      const leadingTrumpTractor: Card[] = [
+        createCard(Suit.Spades, Rank.Three),
+        createCard(Suit.Spades, Rank.Three),
+        createCard(Suit.Spades, Rank.Four),
+        createCard(Suit.Spades, Rank.Four)
+      ];
+      
+      mockState.currentTrick = {
+        leadingCombo: leadingTrumpTractor,
+        plays: [],
+        leadingPlayerId: 'ai1',
+        points: 0
+      };
+      mockState.trumpInfo = trumpInfo;
+      
+      // Human has trump suit pairs (non-consecutive - so not a tractor)
+      const spades5_1 = createCard(Suit.Spades, Rank.Five);
+      const spades5_2 = createCard(Suit.Spades, Rank.Five);
+      const spades7_1 = createCard(Suit.Spades, Rank.Seven);
+      const spades7_2 = createCard(Suit.Spades, Rank.Seven);
+      const spadesAce = createCard(Suit.Spades, Rank.Ace);
+      
+      humanPlayer.hand = [spades5_1, spades5_2, spades7_1, spades7_2, spadesAce];
+      
+      // Should be able to use trump suit pairs to follow trump tractor
+      const validTrumpPairsPlay = [spades5_1, spades5_2, spades7_1, spades7_2];
+      
+      const result = isValidPlay(validTrumpPairsPlay, leadingTrumpTractor, humanPlayer.hand, trumpInfo);
+      
+      expect(result).toBe(true); // Should accept trump suit pairs
+    });
+  });
+  
+  describe('Trump Rank Pairs Count as Valid Pairs', () => {
+    test('Should accept trump rank pairs from different suits when following trump tractor', () => {
+      // Trump is 2 with spades as trump suit
+      const trumpInfo: TrumpInfo = { trumpRank: Rank.Two, declared: true, trumpSuit: Suit.Spades };
+      
+      // AI leads with spades trump tractor: 3-3-4-4 (trump suit tractor)
+      const leadingTrumpTractor: Card[] = [
+        createCard(Suit.Spades, Rank.Three),
+        createCard(Suit.Spades, Rank.Three),
+        createCard(Suit.Spades, Rank.Four),
+        createCard(Suit.Spades, Rank.Four)
+      ];
+      
+      mockState.currentTrick = {
+        leadingCombo: leadingTrumpTractor,
+        plays: [],
+        leadingPlayerId: 'ai1',
+        points: 0
+      };
+      mockState.trumpInfo = trumpInfo;
+      
+      // Human has trump rank pairs (2s) from different suits - these are trump cards
+      const hearts2_1 = createCard(Suit.Hearts, Rank.Two);
+      const hearts2_2 = createCard(Suit.Hearts, Rank.Two);
+      const clubs2_1 = createCard(Suit.Clubs, Rank.Two);
+      const clubs2_2 = createCard(Suit.Clubs, Rank.Two);
+      const spadesAce = createCard(Suit.Spades, Rank.Ace);
+      
+      humanPlayer.hand = [hearts2_1, hearts2_2, clubs2_1, clubs2_2, spadesAce];
+      
+      // Verify these cards are considered trump
+      expect(isTrump(hearts2_1, trumpInfo)).toBe(true);
+      expect(isTrump(hearts2_2, trumpInfo)).toBe(true);
+      expect(isTrump(clubs2_1, trumpInfo)).toBe(true);
+      expect(isTrump(clubs2_2, trumpInfo)).toBe(true);
+      
+      // Should be able to use trump rank pairs (2s) to follow trump tractor
+      const validTrumpRankPairsPlay = [hearts2_1, hearts2_2, clubs2_1, clubs2_2];
+      
+      const result = isValidPlay(validTrumpRankPairsPlay, leadingTrumpTractor, humanPlayer.hand, trumpInfo);
+      
+      expect(result).toBe(true); // Should accept trump rank pairs
+    });
+  });
+  
+  describe('Joker Pairs Count as Valid Pairs', () => {
+    test('Should accept joker pairs when following trump tractor', () => {
+      // Trump is 2 with spades as trump suit
+      const trumpInfo: TrumpInfo = { trumpRank: Rank.Two, declared: true, trumpSuit: Suit.Spades };
+      
+      // AI leads with spades trump tractor: 3-3-4-4
+      const leadingTrumpTractor: Card[] = [
+        createCard(Suit.Spades, Rank.Three),
+        createCard(Suit.Spades, Rank.Three),
+        createCard(Suit.Spades, Rank.Four),
+        createCard(Suit.Spades, Rank.Four)
+      ];
+      
+      mockState.currentTrick = {
+        leadingCombo: leadingTrumpTractor,
+        plays: [],
+        leadingPlayerId: 'ai1',
+        points: 0
+      };
+      mockState.trumpInfo = trumpInfo;
+      
+      // Human has joker pairs
+      const smallJoker1 = createJoker(JokerType.Small);
+      const smallJoker2 = createJoker(JokerType.Small);
+      const bigJoker1 = createJoker(JokerType.Big);
+      const bigJoker2 = createJoker(JokerType.Big);
+      const spadesAce = createCard(Suit.Spades, Rank.Ace);
+      
+      humanPlayer.hand = [smallJoker1, smallJoker2, bigJoker1, bigJoker2, spadesAce];
+      
+      // Verify jokers are considered trump
+      expect(isTrump(smallJoker1, trumpInfo)).toBe(true);
+      expect(isTrump(bigJoker1, trumpInfo)).toBe(true);
+      
+      // Should be able to use joker pairs to follow trump tractor
+      const validJokerPairsPlay = [smallJoker1, smallJoker2, bigJoker1, bigJoker2];
+      
+      const result = isValidPlay(validJokerPairsPlay, leadingTrumpTractor, humanPlayer.hand, trumpInfo);
+      
+      expect(result).toBe(true); // Should accept joker pairs
+    });
+  });
+  
+  describe('Mixed Trump Pairs Should Work', () => {
+    test('Should accept mix of trump suit pairs, trump rank pairs, and joker pairs', () => {
+      // Trump is 2 with spades as trump suit
+      const trumpInfo: TrumpInfo = { trumpRank: Rank.Two, declared: true, trumpSuit: Suit.Spades };
+      
+      // AI leads with big trump tractor: 6 cards (3 pairs)
+      const leadingBigTrumpTractor: Card[] = [
+        createCard(Suit.Spades, Rank.Three),
+        createCard(Suit.Spades, Rank.Three),
+        createCard(Suit.Spades, Rank.Four),
+        createCard(Suit.Spades, Rank.Four),
+        createCard(Suit.Spades, Rank.Five),
+        createCard(Suit.Spades, Rank.Five)
+      ];
+      
+      mockState.currentTrick = {
+        leadingCombo: leadingBigTrumpTractor,
+        plays: [],
+        leadingPlayerId: 'ai1',
+        points: 0
+      };
+      mockState.trumpInfo = trumpInfo;
+      
+      // Human has mixed trump pairs: 1 trump suit pair, 1 trump rank pair, 1 joker pair
+      const spades6_1 = createCard(Suit.Spades, Rank.Six); // Trump suit pair
+      const spades6_2 = createCard(Suit.Spades, Rank.Six);
+      const hearts2_1 = createCard(Suit.Hearts, Rank.Two); // Trump rank pair
+      const hearts2_2 = createCard(Suit.Hearts, Rank.Two);
+      const smallJoker1 = createJoker(JokerType.Small); // Joker pair
+      const smallJoker2 = createJoker(JokerType.Small);
+      const clubsAce = createCard(Suit.Clubs, Rank.Ace);
+      
+      humanPlayer.hand = [spades6_1, spades6_2, hearts2_1, hearts2_2, smallJoker1, smallJoker2, clubsAce];
+      
+      // Should be able to use mixed trump pairs to follow trump tractor
+      const validMixedTrumpPairsPlay = [spades6_1, spades6_2, hearts2_1, hearts2_2, smallJoker1, smallJoker2];
+      
+      const result = isValidPlay(validMixedTrumpPairsPlay, leadingBigTrumpTractor, humanPlayer.hand, trumpInfo);
+      
+      expect(result).toBe(true); // Should accept mixed trump pairs
+    });
+  });
+  
+  describe('Cannot Use Non-Trump Pairs for Trump Tractor', () => {
+    test('Should reject non-trump pairs when player has trump pairs available', () => {
+      // Trump is 2 with spades as trump suit
+      const trumpInfo: TrumpInfo = { trumpRank: Rank.Two, declared: true, trumpSuit: Suit.Spades };
+      
+      // AI leads with spades trump tractor: 3-3-4-4
+      const leadingTrumpTractor: Card[] = [
+        createCard(Suit.Spades, Rank.Three),
+        createCard(Suit.Spades, Rank.Three),
+        createCard(Suit.Spades, Rank.Four),
+        createCard(Suit.Spades, Rank.Four)
+      ];
+      
+      mockState.currentTrick = {
+        leadingCombo: leadingTrumpTractor,
+        plays: [],
+        leadingPlayerId: 'ai1',
+        points: 0
+      };
+      mockState.trumpInfo = trumpInfo;
+      
+      // Human has both trump pairs and non-trump pairs
+      const spades5_1 = createCard(Suit.Spades, Rank.Five); // Trump pair
+      const spades5_2 = createCard(Suit.Spades, Rank.Five);
+      const hearts3_1 = createCard(Suit.Hearts, Rank.Three); // Non-trump pair
+      const hearts3_2 = createCard(Suit.Hearts, Rank.Three);
+      const clubsAce = createCard(Suit.Clubs, Rank.Ace);
+      
+      humanPlayer.hand = [spades5_1, spades5_2, hearts3_1, hearts3_2, clubsAce];
+      
+      // Verify trump status
+      expect(isTrump(spades5_1, trumpInfo)).toBe(true);
+      expect(isTrump(hearts3_1, trumpInfo)).toBe(false);
+      
+      // Should NOT be able to use non-trump pairs when trump pairs are available
+      const invalidNonTrumpPairsPlay = [hearts3_1, hearts3_2, clubsAce, spades5_1]; // Non-trump pair + singles
+      const validTrumpPairsPlay = [spades5_1, spades5_2, hearts3_1, hearts3_2]; // Must use trump pairs
+      
+      const invalidResult = isValidPlay(invalidNonTrumpPairsPlay, leadingTrumpTractor, humanPlayer.hand, trumpInfo);
+      const validResult = isValidPlay(validTrumpPairsPlay, leadingTrumpTractor, humanPlayer.hand, trumpInfo);
+      
+      expect(invalidResult).toBe(false); // Should reject non-trump pairs when trump available
+      expect(validResult).toBe(true); // Should accept when following correctly
+    });
+  });
+  
+  describe('Complex Trump Hierarchy Test', () => {
+    test('Should properly handle complex trump tractor following with all trump types', () => {
+      // Trump is 2 with hearts as trump suit
+      const trumpInfo: TrumpInfo = { trumpRank: Rank.Two, declared: true, trumpSuit: Suit.Hearts };
+      
+      // AI leads with big joker tractor (highest trump): SJ-SJ-BJ-BJ
+      const leadingJokerTractor: Card[] = [
+        createJoker(JokerType.Small),
+        createJoker(JokerType.Small),
+        createJoker(JokerType.Big),
+        createJoker(JokerType.Big)
+      ];
+      
+      mockState.currentTrick = {
+        leadingCombo: leadingJokerTractor,
+        plays: [],
+        leadingPlayerId: 'ai1',
+        points: 0
+      };
+      mockState.trumpInfo = trumpInfo;
+      
+      // Human has various trump cards but no jokers
+      const hearts3_1 = createCard(Suit.Hearts, Rank.Three); // Trump suit pair
+      const hearts3_2 = createCard(Suit.Hearts, Rank.Three);
+      const spades2_1 = createCard(Suit.Spades, Rank.Two); // Trump rank pair  
+      const spades2_2 = createCard(Suit.Spades, Rank.Two);
+      const clubs2_1 = createCard(Suit.Clubs, Rank.Two); // Another trump rank pair
+      const clubs2_2 = createCard(Suit.Clubs, Rank.Two);
+      const heartsAce = createCard(Suit.Hearts, Rank.Ace);
+      
+      humanPlayer.hand = [hearts3_1, hearts3_2, spades2_1, spades2_2, clubs2_1, clubs2_2, heartsAce];
+      
+      // Should be able to use any combination of trump pairs
+      const validTrumpCombination1 = [hearts3_1, hearts3_2, spades2_1, spades2_2]; // Trump suit + trump rank
+      const validTrumpCombination2 = [spades2_1, spades2_2, clubs2_1, clubs2_2]; // Two trump rank pairs
+      
+      const result1 = isValidPlay(validTrumpCombination1, leadingJokerTractor, humanPlayer.hand, trumpInfo);
+      const result2 = isValidPlay(validTrumpCombination2, leadingJokerTractor, humanPlayer.hand, trumpInfo);
+      
+      expect(result1).toBe(true); // Should accept trump suit + trump rank pairs
+      expect(result2).toBe(true); // Should accept multiple trump rank pairs
+    });
+  });
+});

--- a/__tests__/game/trumpTractorFormation.test.ts
+++ b/__tests__/game/trumpTractorFormation.test.ts
@@ -1,0 +1,165 @@
+import { identifyCombos } from '../../src/game/gameLogic';
+import { Suit, Rank, TrumpInfo, ComboType } from '../../src/types';
+import { createCard } from '../helpers/cards';
+
+/**
+ * Test tractor formation with trump cards to understand current validation behavior
+ */
+describe('Trump Tractor Formation Validation', () => {
+  test('Should form tractor with trump cards when 3(C) is trump', () => {
+    // Trump is rank 3 (no trump suit declared)
+    const trumpInfo: TrumpInfo = { 
+      trumpRank: Rank.Three, 
+      declared: true 
+      // No trumpSuit - so only rank 3 cards are trump
+    };
+    
+    // Test cards: 3♣-3♣-4♣-4♣ where 3 is trump rank
+    const clubs3_1 = createCard(Suit.Clubs, Rank.Three);  // Trump card
+    const clubs3_2 = createCard(Suit.Clubs, Rank.Three);  // Trump card  
+    const clubs4_1 = createCard(Suit.Clubs, Rank.Four);   // Regular clubs
+    const clubs4_2 = createCard(Suit.Clubs, Rank.Four);   // Regular clubs
+    
+    const testCards = [clubs3_1, clubs3_2, clubs4_1, clubs4_2];
+    
+    console.log('\n=== TRUMP TRACTOR FORMATION TEST ===');
+    console.log('Trump info:', trumpInfo);
+    console.log('Test cards:', testCards.map(c => `${c.suit}-${c.rank}`));
+    
+    // Identify all possible combos from these cards
+    const combos = identifyCombos(testCards, trumpInfo);
+    
+    console.log('\nIdentified combos:');
+    combos.forEach((combo, i) => {
+      if (combo.cards.length > 1) { // Only show pairs/tractors
+        console.log(`  ${i}: ${combo.type} (${combo.cards.length} cards) - ${combo.cards.map(c => `${c.suit}-${c.rank}`).join(', ')} (value: ${combo.value})`);
+      }
+    });
+    
+    // Look for tractor combos specifically
+    const tractorCombos = combos.filter(combo => combo.type === ComboType.Tractor);
+    const fourCardTractors = tractorCombos.filter(combo => combo.cards.length === 4);
+    
+    console.log('\nFour-card tractors found:', fourCardTractors.length);
+    fourCardTractors.forEach((tractor, i) => {
+      console.log(`  Tractor ${i}: ${tractor.cards.map(c => `${c.suit}-${c.rank}`).join(', ')}`);
+    });
+    
+    // Key question: Does 3♣-3♣-4♣-4♣ form a valid tractor?
+    // Since 3 is trump rank, the 3♣ cards are trump
+    // The 4♣ cards are regular clubs
+    // This means we have: trump-trump-clubs-clubs
+    // Can trump cards and non-trump cards of the same suit form a tractor?
+    
+    const expectedTractorExists = fourCardTractors.some(tractor => {
+      const cardIds = tractor.cards.map(c => c.id).sort();
+      const testCardIds = testCards.map(c => c.id).sort();
+      return JSON.stringify(cardIds) === JSON.stringify(testCardIds);
+    });
+    
+    console.log('\nExpected tractor (3♣-3♣-4♣-4♣) exists:', expectedTractorExists);
+    
+    if (expectedTractorExists) {
+      console.log('✅ CURRENT BEHAVIOR: Mixed trump/non-trump cards CAN form tractors');
+    } else {
+      console.log('❌ CURRENT BEHAVIOR: Mixed trump/non-trump cards CANNOT form tractors');
+      
+      // Let's see what pairs we do get
+      const pairCombos = combos.filter(combo => combo.type === ComboType.Pair);
+      console.log('\nPairs found instead:');
+      pairCombos.forEach((pair, i) => {
+        console.log(`  Pair ${i}: ${pair.cards.map(c => `${c.suit}-${c.rank}`).join(', ')}`);
+      });
+    }
+    
+    // This test documents current behavior rather than asserting expected behavior
+    // We'll use this to understand how the system currently works
+    expect(combos.length).toBeGreaterThan(0); // At least some combos should be found
+  });
+  
+  test('Should form tractor with trump suit cards when Hearts is trump suit', () => {
+    // Trump is Hearts suit with rank 2
+    const trumpInfo: TrumpInfo = { 
+      trumpRank: Rank.Two, 
+      declared: true,
+      trumpSuit: Suit.Hearts 
+    };
+    
+    // Test cards: 3♥-3♥-4♥-4♥ where Hearts is trump suit
+    const hearts3_1 = createCard(Suit.Hearts, Rank.Three);  // Trump suit
+    const hearts3_2 = createCard(Suit.Hearts, Rank.Three);  // Trump suit
+    const hearts4_1 = createCard(Suit.Hearts, Rank.Four);   // Trump suit
+    const hearts4_2 = createCard(Suit.Hearts, Rank.Four);   // Trump suit
+    
+    const testCards = [hearts3_1, hearts3_2, hearts4_1, hearts4_2];
+    
+    console.log('\n=== TRUMP SUIT TRACTOR FORMATION TEST ===');
+    console.log('Trump info:', trumpInfo);
+    console.log('Test cards:', testCards.map(c => `${c.suit}-${c.rank}`));
+    
+    const combos = identifyCombos(testCards, trumpInfo);
+    
+    // Look for tractor combos
+    const tractorCombos = combos.filter(combo => combo.type === ComboType.Tractor);
+    const fourCardTractors = tractorCombos.filter(combo => combo.cards.length === 4);
+    
+    console.log('\nFour-card tractors found:', fourCardTractors.length);
+    fourCardTractors.forEach((tractor, i) => {
+      console.log(`  Tractor ${i}: ${tractor.cards.map(c => `${c.suit}-${c.rank}`).join(', ')}`);
+    });
+    
+    const heartsTractorExists = fourCardTractors.some(tractor => {
+      const cardIds = tractor.cards.map(c => c.id).sort();
+      const testCardIds = testCards.map(c => c.id).sort();
+      return JSON.stringify(cardIds) === JSON.stringify(testCardIds);
+    });
+    
+    console.log('\nExpected Hearts tractor (3♥-3♥-4♥-4♥) exists:', heartsTractorExists);
+    
+    if (heartsTractorExists) {
+      console.log('✅ CURRENT BEHAVIOR: Trump suit cards CAN form tractors');
+    } else {
+      console.log('❌ CURRENT BEHAVIOR: Trump suit cards CANNOT form tractors');
+    }
+    
+    expect(combos.length).toBeGreaterThan(0);
+  });
+  
+  test('Should form tractor with non-trump cards', () => {
+    // Trump is rank 2 with no trump suit
+    const trumpInfo: TrumpInfo = { 
+      trumpRank: Rank.Two, 
+      declared: true 
+    };
+    
+    // Test cards: 5♠-5♠-6♠-6♠ (all non-trump)
+    const spades5_1 = createCard(Suit.Spades, Rank.Five);   // Non-trump
+    const spades5_2 = createCard(Suit.Spades, Rank.Five);   // Non-trump
+    const spades6_1 = createCard(Suit.Spades, Rank.Six);    // Non-trump
+    const spades6_2 = createCard(Suit.Spades, Rank.Six);    // Non-trump
+    
+    const testCards = [spades5_1, spades5_2, spades6_1, spades6_2];
+    
+    console.log('\n=== NON-TRUMP TRACTOR FORMATION TEST ===');
+    console.log('Trump info:', trumpInfo);
+    console.log('Test cards:', testCards.map(c => `${c.suit}-${c.rank}`));
+    
+    const combos = identifyCombos(testCards, trumpInfo);
+    
+    const tractorCombos = combos.filter(combo => combo.type === ComboType.Tractor);
+    const fourCardTractors = tractorCombos.filter(combo => combo.cards.length === 4);
+    
+    console.log('\nFour-card tractors found:', fourCardTractors.length);
+    
+    const spadesTractorExists = fourCardTractors.some(tractor => {
+      const cardIds = tractor.cards.map(c => c.id).sort();
+      const testCardIds = testCards.map(c => c.id).sort();
+      return JSON.stringify(cardIds) === JSON.stringify(testCardIds);
+    });
+    
+    console.log('Non-trump tractor (5♠-5♠-6♠-6♠) exists:', spadesTractorExists);
+    
+    // This should definitely work - non-trump cards of same suit forming tractor
+    expect(spadesTractorExists).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes AI logic bug where bots were playing invalid cards when following tractors by bypassing proper combo identification
- Enhances validation logic to enforce trump pair hierarchy rules when following trump tractors/pairs  
- Ensures both AI decision-making and human validation follow consistent tractor hierarchy rules

## Test plan
- [x] All existing tests pass (354 tests)
- [x] New comprehensive test coverage for tractor following rules
- [x] AI generates valid moves when following trump tractors
- [x] Validation enforces trump pair hierarchy correctly
- [x] Edge cases handled properly (insufficient trumps, mixed scenarios)

🤖 Generated with [Claude Code](https://claude.ai/code)