### PR TITLE
Fix trump hierarchy bug where trump rank pairs lose to trump suit pairs (issue #74)

### DIFF
--- a/__tests__/game/issue74TrumpHierarchy.test.ts
+++ b/__tests__/game/issue74TrumpHierarchy.test.ts
@@ -1,0 +1,87 @@
+import { compareCardCombos } from '../../src/game/gameLogic';
+import { Suit, Rank, TrumpInfo } from '../../src/types';
+import { createCard } from '../helpers/cards';
+
+/**
+ * Test for issue #74: Trump rank pair should win trump suit pair
+ * 
+ * Expected trump hierarchy:
+ * BJ > SJ > Trump rank in trump suit > trump rank in other suits > other trump suit cards
+ * 
+ * Bug: When comparing pairs from the same trump suit, the system was using rank comparison
+ * instead of trump hierarchy, causing trump suit pairs to incorrectly beat trump rank pairs.
+ * 
+ * Example from issue:
+ * - Trump: 2♦ (rank 2, Diamonds suit)
+ * - Expected: 2♦-2♦ should beat 9♦-9♦
+ * - Actual (before fix): 2♦-2♦ was losing to 9♦-9♦
+ */
+describe('Issue #74: Trump Hierarchy Bug Fix', () => {
+  test('Exact issue reproduction: 2♦-2♦ should beat 9♦-9♦ when 2♦ is trump', () => {
+    // Set up trump as described in issue: 2(D) is trump
+    const trumpInfo: TrumpInfo = { 
+      trumpRank: Rank.Two, 
+      declared: true,
+      trumpSuit: Suit.Diamonds 
+    };
+    
+    // Create the exact cards from the issue
+    const diamonds2_1 = createCard(Suit.Diamonds, Rank.Two);   // Trump rank in trump suit
+    const diamonds2_2 = createCard(Suit.Diamonds, Rank.Two);   
+    const diamonds9_1 = createCard(Suit.Diamonds, Rank.Nine);  // Trump suit card
+    const diamonds9_2 = createCard(Suit.Diamonds, Rank.Nine);  
+    
+    const trumpRankPair = [diamonds2_1, diamonds2_2];  // 2♦-2♦ 
+    const trumpSuitPair = [diamonds9_1, diamonds9_2];  // 9♦-9♦
+    
+    // This is the exact comparison from the issue description
+    const result = compareCardCombos(trumpRankPair, trumpSuitPair, trumpInfo);
+    
+    // Expected behavior: 2♦-2♦ > 9♦-9♦ (should return positive)
+    expect(result).toBeGreaterThan(0);
+  });
+  
+  test('Trump hierarchy is consistent across different trump configurations', () => {
+    // Test with different trump rank and suit to ensure fix is general
+    const trumpInfo: TrumpInfo = { 
+      trumpRank: Rank.Five, 
+      declared: true,
+      trumpSuit: Suit.Hearts 
+    };
+    
+    const hearts5_1 = createCard(Suit.Hearts, Rank.Five);    // Trump rank in trump suit (highest)
+    const hearts5_2 = createCard(Suit.Hearts, Rank.Five);    
+    const hearts10_1 = createCard(Suit.Hearts, Rank.Ten);    // Trump suit card (lower)
+    const hearts10_2 = createCard(Suit.Hearts, Rank.Ten);    
+    
+    const trumpRankPair = [hearts5_1, hearts5_2];    // 5♥-5♥
+    const trumpSuitPair = [hearts10_1, hearts10_2];  // 10♥-10♥
+    
+    const result = compareCardCombos(trumpRankPair, trumpSuitPair, trumpInfo);
+    
+    // Trump rank pair should always beat trump suit pair
+    expect(result).toBeGreaterThan(0);
+  });
+  
+  test('Cross-suit trump pairs still work correctly', () => {
+    // Ensure fix doesn't break cross-suit trump comparisons
+    const trumpInfo: TrumpInfo = { 
+      trumpRank: Rank.Ace, 
+      declared: true,
+      trumpSuit: Suit.Spades 
+    };
+    
+    const spades2_1 = createCard(Suit.Spades, Rank.Two);    // Trump suit card
+    const spades2_2 = createCard(Suit.Spades, Rank.Two);    
+    const heartsA_1 = createCard(Suit.Hearts, Rank.Ace);    // Trump rank in other suit
+    const heartsA_2 = createCard(Suit.Hearts, Rank.Ace);    
+    
+    const trumpSuitPair = [spades2_1, spades2_2];   // 2♠-2♠ (trump suit)
+    const trumpRankPair = [heartsA_1, heartsA_2];   // A♥-A♥ (trump rank in other suit)
+    
+    const result = compareCardCombos(trumpRankPair, trumpSuitPair, trumpInfo);
+    
+    // Trump rank in other suits beats trump suit cards
+    expect(result).toBeGreaterThan(0);
+  });
+});

--- a/src/game/gameLogic.ts
+++ b/src/game/gameLogic.ts
@@ -848,6 +848,11 @@ export const compareCardCombos = (
         comboB[0].suit &&
         comboA[0].suit === comboB[0].suit
       ) {
+        // If both pairs are trump cards, use trump hierarchy instead of rank comparison
+        if (aIsTrump && bIsTrump) {
+          return compareCards(comboA[0], comboB[0], trumpInfo);
+        }
+        // For non-trump pairs from same suit, use rank comparison
         return compareRanks(comboA[0].rank, comboB[0].rank);
       } else {
         // Different suits and both are pairs - if both are trump pairs, compare by trump level


### PR DESCRIPTION
## Summary
- Fixes trump hierarchy bug where trump rank pairs were incorrectly losing to trump suit pairs when both were from the same suit
- Ensures proper trump hierarchy: BJ > SJ > Trump rank in trump suit > trump rank in other suits > other trump suit cards

## Problem
When comparing pairs from the same trump suit (e.g., 2♦-2♦ vs 9♦-9♦ when 2♦ is trump), the system was using rank comparison instead of trump hierarchy, causing 9♦-9♦ to incorrectly beat 2♦-2♦.

## Solution  
Enhanced `compareCardCombos` to use trump hierarchy (`compareCards`) when both pairs are trump cards from the same suit, while preserving existing functionality for cross-suit comparisons.

## Test plan
- [x] Exact issue case: 2♦-2♦ now correctly beats 9♦-9♦ when 2♦ is trump
- [x] Different trump configurations work correctly (5♥-5♥ beats 10♥-10♥ when 5♥ is trump)
- [x] Cross-suit trump comparisons still work (A♥-A♥ beats 2♠-2♠ when A♠ is trump)
- [x] All existing trump-related tests continue to pass (36 tests)

🤖 Generated with [Claude Code](https://claude.ai/code)