### PR TITLE
Fix auto-selection not working after skipping trump declaration (issue #78)

### DIFF
--- a/__tests__/game/issue78AutoSelectAfterSkipTrump.test.ts
+++ b/__tests__/game/issue78AutoSelectAfterSkipTrump.test.ts
@@ -1,0 +1,117 @@
+import { declareTrumpSuit } from '../../src/game/trumpManager';
+import { getAutoSelectedCards } from '../../src/utils/cardAutoSelection';
+import { createIsolatedGameState } from '../helpers/testIsolation';
+import { Card, Suit, Rank, GamePhase } from '../../src/types';
+
+describe('Issue #78: Auto-select after trump declaration skip', () => {
+  it('should enable auto-selection after skipping trump declaration', () => {
+    // Create initial game state
+    const gameState = createIsolatedGameState();
+    
+    // Ensure we're in declaring phase initially
+    gameState.gamePhase = GamePhase.Declaring;
+    gameState.trumpInfo.declared = false;
+    
+    console.log('Initial state - declared:', gameState.trumpInfo.declared);
+    console.log('Initial phase:', gameState.gamePhase);
+    
+    // Skip trump declaration (pass null)
+    const stateAfterSkip = declareTrumpSuit(gameState, null);
+    
+    console.log('After skip - declared:', stateAfterSkip.trumpInfo.declared);
+    console.log('After skip phase:', stateAfterSkip.gamePhase);
+    
+    // Verify trump declaration is marked as complete
+    expect(stateAfterSkip.trumpInfo.declared).toBe(true);
+    expect(stateAfterSkip.gamePhase).toBe(GamePhase.Playing);
+    
+    // Create test cards for auto-selection
+    const testCards: Card[] = [
+      {
+        id: 'hearts-5-1',
+        suit: Suit.Hearts,
+        rank: Rank.Five,
+        joker: undefined,
+        points: 5
+      },
+      {
+        id: 'hearts-5-2', 
+        suit: Suit.Hearts,
+        rank: Rank.Five,
+        joker: undefined,
+        points: 5
+      },
+      {
+        id: 'hearts-6-1',
+        suit: Suit.Hearts,
+        rank: Rank.Six,
+        joker: undefined,
+        points: 0
+      }
+    ];
+    
+    // Test auto-selection with the fixed trump info
+    const autoSelected = getAutoSelectedCards(
+      testCards[0], // Click first 5 of Hearts
+      testCards,
+      [], // No current selection
+      true, // Leading
+      undefined, // No leading combo
+      stateAfterSkip.trumpInfo // Use the fixed trump info
+    );
+    
+    console.log('Auto-selected cards:', autoSelected.map(c => `${c.rank}${c.suit}`));
+    
+    // Should auto-select the pair of 5s
+    expect(autoSelected.length).toBe(2);
+    expect(autoSelected).toContainEqual(testCards[0]);
+    expect(autoSelected).toContainEqual(testCards[1]);
+  });
+  
+  it('should enable auto-selection after declaring a trump suit', () => {
+    // Create initial game state
+    const gameState = createIsolatedGameState();
+    gameState.gamePhase = GamePhase.Declaring;
+    gameState.trumpInfo.declared = false;
+    
+    // Declare Hearts as trump
+    const stateAfterDeclaration = declareTrumpSuit(gameState, Suit.Hearts);
+    
+    // Verify trump declaration is complete
+    expect(stateAfterDeclaration.trumpInfo.declared).toBe(true);
+    expect(stateAfterDeclaration.trumpInfo.trumpSuit).toBe(Suit.Hearts);
+    expect(stateAfterDeclaration.gamePhase).toBe(GamePhase.Playing);
+    
+    // Test auto-selection works with declared trump
+    const testCards: Card[] = [
+      {
+        id: 'spades-7-1',
+        suit: Suit.Spades,
+        rank: Rank.Seven,
+        joker: undefined,
+        points: 0
+      },
+      {
+        id: 'spades-7-2',
+        suit: Suit.Spades, 
+        rank: Rank.Seven,
+        joker: undefined,
+        points: 0
+      }
+    ];
+    
+    const autoSelected = getAutoSelectedCards(
+      testCards[0],
+      testCards,
+      [],
+      true,
+      undefined,
+      stateAfterDeclaration.trumpInfo
+    );
+    
+    // Should auto-select the pair
+    expect(autoSelected.length).toBe(2);
+    expect(autoSelected).toContainEqual(testCards[0]);
+    expect(autoSelected).toContainEqual(testCards[1]);
+  });
+});

--- a/__tests__/game/trumpManager.test.ts
+++ b/__tests__/game/trumpManager.test.ts
@@ -34,15 +34,15 @@ describe('trumpManager', () => {
       expect(result.gamePhase).toBe('playing');
     });
 
-    test('should update game phase without setting trump suit when skipping declaration', () => {
+    test('should update game phase and mark declaration complete when skipping declaration', () => {
       const mockState = createMockGameState();
       const result = declareTrumpSuit(mockState, null);
       
       // Verify trump suit remains undefined
       expect(result.trumpInfo.trumpSuit).toBeUndefined();
       
-      // Verify declared flag was not set
-      expect(result.trumpInfo.declared).toBe(false);
+      // Verify declared flag was set to complete the declaration phase
+      expect(result.trumpInfo.declared).toBe(true);
       
       // Verify game phase was updated
       expect(result.gamePhase).toBe('playing');

--- a/src/game/trumpManager.ts
+++ b/src/game/trumpManager.ts
@@ -20,6 +20,9 @@ export function declareTrumpSuit(
     // Record the player who declared trump
     const currentPlayer = newState.players[newState.currentPlayerIndex];
     newState.trumpInfo.declarerPlayerId = currentPlayer.id;
+  } else {
+    // Trump declaration was skipped - mark as declared to complete the phase
+    newState.trumpInfo.declared = true;
   }
 
   // Save the starting player for this round when transitioning to Playing phase


### PR DESCRIPTION
## Summary
- Fixed auto-selection functionality not working after skipping trump declaration
- Updated trump manager to properly mark declaration phase as complete when skipped
- Added comprehensive test coverage for the fix

## Problem Solved
**Issue #78**: Auto-selection wasn't working when trump declaration was skipped. Users could only select single cards instead of smart pair/tractor selection.

## Root Cause
The `declareTrumpSuit()` function only set `trumpInfo.declared = true` when a trump suit was actually declared, but not when declaration was skipped (`suit = null`). This left the auto-selection logic in "trump declaration mode" where only single cards could be selected.

## Solution
Updated `declareTrumpSuit()` to set `declared = true` in both scenarios:
- ✅ When a trump suit is declared
- ✅ When trump declaration is skipped (NEW)

## Code Changes
```typescript
// Before (broken)
if (suit) {
  newState.trumpInfo.declared = true;
  // ... other trump logic
}
// declared stays false when skipping ❌

// After (fixed)  
if (suit) {
  newState.trumpInfo.declared = true;
  // ... other trump logic
} else {
  // Trump declaration was skipped - mark as declared to complete the phase
  newState.trumpInfo.declared = true; // ✅
}
```

## Test Results
- ✅ Auto-selection works after skipping trump declaration
- ✅ Auto-selection works after declaring trump suit  
- ✅ All existing functionality preserved
- ✅ 379/379 tests passing (100% pass rate)

## Files Changed
- `src/game/trumpManager.ts` - Fixed trump declaration completion logic
- `__tests__/game/trumpManager.test.ts` - Updated test to expect correct behavior
- `__tests__/game/issue78AutoSelectAfterSkipTrump.test.ts` - Added comprehensive test coverage

🤖 Generated with [Claude Code](https://claude.ai/code)