### PR TITLE
Fix EAS CLI file watcher ENOSPC errors in GitHub Actions

### DIFF
--- a/.github/actions/eas-update/action.yml
+++ b/.github/actions/eas-update/action.yml
@@ -7,10 +7,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Install EAS CLI globally
-      run: npm install -g eas-cli
-      shell: bash
-
     - name: Setup Expo
       uses: expo/expo-github-action@v8
       with:
@@ -29,15 +25,12 @@ runs:
         
         # Get base version and commit count (only look for version tags)
         LAST_TAG=$(git tag -l "v*.*.*" --sort=-version:refname | head -n1 || echo "")
-        echo "DEBUG: LAST_TAG='$LAST_TAG'"
         if [[ -n "$LAST_TAG" ]]; then
           BASE_VERSION=${LAST_TAG#v}
           COMMIT_COUNT=$(git rev-list --count ${LAST_TAG}..HEAD)
-          echo "DEBUG: Found tag $LAST_TAG, BASE_VERSION=$BASE_VERSION, COMMIT_COUNT=$COMMIT_COUNT"
         else
           BASE_VERSION="1.0.0"
           COMMIT_COUNT=$(git rev-list --count HEAD)
-          echo "DEBUG: No tags found, BASE_VERSION=$BASE_VERSION, COMMIT_COUNT=$COMMIT_COUNT"
         fi
         
         # Determine deployment based on trigger


### PR DESCRIPTION
## Summary
- Remove global EAS CLI installation from GitHub Actions workflow to prevent file watcher ENOSPC errors
- Clean up debug logging statements that are no longer needed

## Problem
The `npm install -g eas-cli` command in the EAS update action was creating too many file watchers, causing ENOSPC (No space left on device) errors in GitHub Actions runners due to inotify limits.

## Solution
- Removed the global npm install step for EAS CLI
- Assumes EAS CLI is available in the runner environment or uses alternative approach
- Cleaned up debug logging statements

## Test plan
- [ ] Verify EAS update workflows run without ENOSPC errors
- [ ] Confirm EAS CLI functionality still works in CI/CD pipeline
- [ ] Monitor for any regression in deployment processes

🤖 Generated with [Claude Code](https://claude.ai/code)