### PR TITLE
revert: remove inotify watchers limit steps that don't work in CI

### DIFF
--- a/.github/workflows/eas-build-apk.yml
+++ b/.github/workflows/eas-build-apk.yml
@@ -18,12 +18,6 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Increase inotify watchers limit
-      run: |
-        sudo sysctl -w fs.inotify.max_user_watches=524288
-        sudo sysctl -w fs.inotify.max_user_instances=524288
-        sudo sysctl -w fs.inotify.max_queued_events=524288
-
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/eas-update.yml
+++ b/.github/workflows/eas-update.yml
@@ -27,12 +27,6 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Increase inotify watchers limit
-      run: |
-        sudo sysctl -w fs.inotify.max_user_watches=524288
-        sudo sysctl -w fs.inotify.max_user_instances=524288
-        sudo sysctl -w fs.inotify.max_queued_events=524288
-
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -18,12 +18,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: Increase inotify watchers limit
-      run: |
-        sudo sysctl -w fs.inotify.max_user_watches=524288
-        sudo sysctl -w fs.inotify.max_user_instances=524288
-        sudo sysctl -w fs.inotify.max_queued_events=524288
-
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:


### PR DESCRIPTION
## Summary
Remove inotify watchers limit steps from all GitHub workflows as they don't work in the CI environment.

## Problem
The inotify watchers limit configuration added in PR #143 doesn't persist in GitHub Actions runners and doesn't solve ENOSPC issues in CI.

## Solution
Remove the following steps from all workflows:
```bash
- name: Increase inotify watchers limit
  run:  < /dev/null | 
    sudo sysctl -w fs.inotify.max_user_watches=524288
    sudo sysctl -w fs.inotify.max_user_instances=524288
    sudo sysctl -w fs.inotify.max_queued_events=524288
```

## Benefits
- Cleaner workflow files without ineffective steps
- Faster CI execution by removing unnecessary commands
- Maintains the BASE_VERSION calculation improvements from PR #143

## Test plan
- [x] Verified workflows run without inotify steps locally
- [ ] Monitor CI for continued functionality

🤖 Generated with [Claude Code](https://claude.ai/code)