### PR TITLE
Fix tractor validation for longer non-trump suit combinations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ npm run qualitycheck  # Runs all checks
 - **NO LINT WARNINGS/ERRORS**: All ESLint warnings and errors must be resolved.
 - **TYPECHECK MUST PASS**: No TypeScript compilation errors allowed.
 - **Zero Tolerance Policy**: `npm run qualitycheck` must pass completely with no failures or warnings before any commit.
-- **Current Test Count**: 528 tests passing (update README.md badge when count changes)
+- **Current Test Count**: 532 tests passing (update README.md badge when count changes)
 
 ### Git Workflow
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A React Native implementation of the classic Chinese card game **Tractor** (also
 ![Platforms](https://img.shields.io/badge/Platforms-Android%20%7C%20iOS-blue)
 ![React Native](https://img.shields.io/badge/React%20Native-Expo-blue)
 ![TypeScript](https://img.shields.io/badge/TypeScript-Strict-green)
-![Tests](https://img.shields.io/badge/Tests-528%20Passing-brightgreen?logo=jest)
+![Tests](https://img.shields.io/badge/Tests-532%20Passing-brightgreen?logo=jest)
 ![EAS Update](https://github.com/ejfn/Tractor/actions/workflows/eas-update.yml/badge.svg?branch=main)
 ![EAS Build APK](https://github.com/ejfn/Tractor/actions/workflows/eas-build-apk.yml/badge.svg?branch=main)
 

--- a/__tests__/game/tractorLengthBug.test.ts
+++ b/__tests__/game/tractorLengthBug.test.ts
@@ -1,0 +1,92 @@
+import { identifyCombos } from '../../src/game/gameLogic';
+import { validatePlay } from '../../src/game/gamePlayManager';
+import { createFullGameStateWithTricks } from '../helpers';
+import { Rank, Suit, ComboType, TrumpInfo } from '../../src/types';
+
+describe('Tractor Length Bug Fix', () => {
+  const createDiamondCards = (ranks: Rank[]) => {
+    return ranks.flatMap(rank => [
+      { id: `${rank}_${Suit.Diamonds}_1`, rank, suit: Suit.Diamonds, points: 0 },
+      { id: `${rank}_${Suit.Diamonds}_2`, rank, suit: Suit.Diamonds, points: 0 }
+    ]);
+  };
+
+  const trumpInfo: TrumpInfo = {
+    trumpRank: Rank.Two,
+    trumpSuit: Suit.Spades, // Diamonds is NOT trump
+  };
+
+  it('should identify 66-77-88 diamond tractor (3 pairs) when diamonds is non-trump', () => {
+    const tractorCards = createDiamondCards([Rank.Six, Rank.Seven, Rank.Eight]);
+    
+    const combos = identifyCombos(tractorCards, trumpInfo);
+    const tractors = combos.filter(combo => combo.type === ComboType.Tractor);
+    
+    // Should find the full 3-pair tractor and at least one sub-tractor
+    expect(tractors.length).toBeGreaterThanOrEqual(2);
+    
+    // Should include the full 3-pair tractor
+    const fullTractor = tractors.find(t => t.cards.length === 6);
+    expect(fullTractor).toBeDefined();
+    expect(fullTractor!.cards).toHaveLength(6);
+    
+    // Should contain all 6 cards of the right ranks
+    expect(fullTractor!.cards.every(card => 
+      card.suit === Suit.Diamonds && 
+      [Rank.Six, Rank.Seven, Rank.Eight].includes(card.rank!)
+    )).toBe(true);
+  });
+
+  it('should validate 66-77-88 diamond tractor as valid leading play', () => {
+    const gameState = createFullGameStateWithTricks();
+    gameState.trumpInfo = trumpInfo;
+    gameState.currentTrick = null; // Leading player
+    
+    const tractorCards = createDiamondCards([Rank.Six, Rank.Seven, Rank.Eight]);
+    gameState.players[0].hand = tractorCards;
+    
+    // Should be valid when leading
+    const isValid = validatePlay(gameState, tractorCards);
+    expect(isValid).toBe(true);
+  });
+
+  it('should identify longer tractors like 55-66-77-88-99 (5 pairs)', () => {
+    const longTractorCards = createDiamondCards([
+      Rank.Five, Rank.Six, Rank.Seven, Rank.Eight, Rank.Nine
+    ]);
+    
+    const combos = identifyCombos(longTractorCards, trumpInfo);
+    const tractors = combos.filter(combo => combo.type === ComboType.Tractor);
+    
+    // Should find multiple tractors of different lengths
+    expect(tractors.length).toBeGreaterThan(1);
+    
+    // Should include the full 5-pair tractor
+    const fullTractor = tractors.find(t => t.cards.length === 10);
+    expect(fullTractor).toBeDefined();
+    expect(fullTractor!.cards).toHaveLength(10);
+  });
+
+  it('should identify multiple shorter tractors within a longer sequence', () => {
+    const cards = createDiamondCards([
+      Rank.Five, Rank.Six, Rank.Seven, Rank.Eight, Rank.Nine
+    ]);
+    
+    const combos = identifyCombos(cards, trumpInfo);
+    const tractors = combos.filter(combo => combo.type === ComboType.Tractor);
+    
+    // Should find multiple tractors of different lengths starting from different positions
+    expect(tractors.length).toBeGreaterThanOrEqual(4);
+    
+    // Should include the longest tractor (10 cards)
+    const longestTractor = tractors.reduce((longest, current) => 
+      current.cards.length > longest.cards.length ? current : longest
+    );
+    expect(longestTractor.cards).toHaveLength(10);
+    
+    // Should include shorter tractors
+    const tractorLengths = tractors.map(t => t.cards.length).sort();
+    expect(tractorLengths).toContain(4); // At least one 2-pair tractor
+    expect(tractorLengths).toContain(10); // The full 5-pair tractor
+  });
+});

--- a/src/game/gameLogic.ts
+++ b/src/game/gameLogic.ts
@@ -893,20 +893,33 @@ const findTractors = (
   // Sort pairs by rank value
   pairs.sort((a, b) => getRankValue(a.rank) - getRankValue(b.rank));
 
-  // Find consecutive pairs to form tractors
-  for (let i = 0; i < pairs.length - 1; i++) {
-    const currentRankValue = getRankValue(pairs[i].rank);
-    const nextRankValue = getRankValue(pairs[i + 1].rank);
+  // Find consecutive pairs to form tractors of any length
+  for (let startIdx = 0; startIdx < pairs.length; startIdx++) {
+    // Build the longest possible tractor starting from this position
+    const tractorPairs = [pairs[startIdx]];
+    let currentIdx = startIdx;
 
-    // Check if consecutive
-    if (nextRankValue - currentRankValue === 1) {
-      // Found a tractor!
-      const tractorCards = [...pairs[i].cards, ...pairs[i + 1].cards];
+    // Keep adding consecutive pairs
+    while (currentIdx + 1 < pairs.length) {
+      const currentRankValue = getRankValue(pairs[currentIdx].rank);
+      const nextRankValue = getRankValue(pairs[currentIdx + 1].rank);
+
+      // Check if next pair is consecutive
+      if (nextRankValue - currentRankValue === 1) {
+        tractorPairs.push(pairs[currentIdx + 1]);
+        currentIdx++;
+      } else {
+        break; // No more consecutive pairs
+      }
+    }
+
+    // Only add tractor if it has at least 2 pairs (4 cards)
+    if (tractorPairs.length >= 2) {
+      const tractorCards = tractorPairs.flatMap((pair) => pair.cards);
 
       // Calculate value based on the highest rank in the tractor
       const value = Math.max(
-        getCardValue(pairs[i].cards[0], trumpInfo),
-        getCardValue(pairs[i + 1].cards[0], trumpInfo),
+        ...tractorPairs.map((pair) => getCardValue(pair.cards[0], trumpInfo)),
       );
 
       combos.push({


### PR DESCRIPTION
## Summary

- Fix tractor identification to support 3+ consecutive pairs (#145)
- Enable human players to select valid longer non-trump tractors like 66-77-88 diamonds
- Previously limited to 2-pair tractors due to algorithm constraint
- AI validation already working correctly with same underlying logic

## Key Changes

### Core Algorithm Fix
- **Modified `findTractors` function** in `src/game/gameLogic.ts`
- **Before**: Only checked consecutive pair combinations (i, i+1) → limited to 2-pair tractors
- **After**: Builds longest possible tractor from each starting position → supports any length

### Algorithm Details
```typescript
// OLD: Only 2-pair tractors
for (let i = 0; i < pairs.length - 1; i++) {
  // Check pairs[i] and pairs[i+1] only
}

// NEW: Tractors of any length
for (let startIdx = 0; startIdx < pairs.length; startIdx++) {
  const tractorPairs = [pairs[startIdx]];
  // Keep adding consecutive pairs until sequence breaks
  while (consecutive) {
    tractorPairs.push(nextPair);
  }
}
```

### Validation Impact
- **Human Selection**: Now correctly validates 66-77-88 diamond tractors when diamonds non-trump
- **AI Behavior**: No changes needed - AI already uses same validation logic
- **Game Rules**: Proper implementation of Tractor rules for longer combinations

### Test Coverage
- **New test suite**: `tractorLengthBug.test.ts` with 4 comprehensive tests
- **3-pair tractors**: 66-77-88 diamonds validation
- **5-pair tractors**: 55-66-77-88-99 identification  
- **Mixed lengths**: Multiple tractor combinations within sequences
- **Leading validation**: Confirms tractors valid for game play

## Test Plan

- [x] All 532 tests passing (4 new tests added)
- [x] TypeScript compilation successful
- [x] ESLint checks passing
- [x] Quality check complete
- [x] Longer tractor identification verified
- [x] Human play validation confirmed
- [x] No regressions in existing functionality

## Impact

### Before Fix
- ❌ 66-77-88 diamonds blocked from selection
- ❌ Only 2-pair tractors (4 cards) supported
- ❌ Invalid game rule implementation

### After Fix  
- ✅ 66-77-88 diamonds correctly identified as valid tractor
- ✅ Tractors of any length (6, 8, 10+ cards) supported
- ✅ Proper Tractor game rule compliance
- ✅ Enhanced gameplay for human players

🤖 Generated with [Claude Code](https://claude.ai/code)