### PR TITLE
fix: update workflows to use correct version outputs

### DIFF
--- a/.github/workflows/eas-build-apk.yml
+++ b/.github/workflows/eas-build-apk.yml
@@ -54,12 +54,12 @@ jobs:
 
     - name: Download APK
       run: |
-        curl -L -o tractor-${{ steps.version.outputs.version }}.apk "${{ steps.build-url.outputs.build_url }}"
+        curl -L -o tractor-${{ steps.version.outputs.app-version }}.apk "${{ steps.build-url.outputs.build_url }}"
 
     - name: Upload APK to Release
       uses: softprops/action-gh-release@v2
       with:
-        files: tractor-${{ steps.version.outputs.version }}.apk
+        files: tractor-${{ steps.version.outputs.app-version }}.apk
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/eas-update.yml
+++ b/.github/workflows/eas-update.yml
@@ -51,6 +51,6 @@ jobs:
       uses: ./.github/actions/git-version
 
     - name: EAS Update
-      run: eas update --branch ${{ steps.version.outputs.eas-branch }} --message "Update ${{ steps.version.outputs.version }}"
+      run: eas update --branch ${{ steps.version.outputs.eas-branch }} --message "Update ${{ steps.version.outputs.full-version }}"
       env:
         EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}


### PR DESCRIPTION
## Summary
- Updates EAS Update workflow to use `full-version` for detailed update messages
- Updates EAS Build APK workflow to use `app-version` for clean APK filenames 
- Fixes workflows after git-version action output changes in previous PR

## Key Changes
- **EAS Update**: Now uses `full-version` (e.g., "Update v1.0.3+abc1234") for complete tracking
- **EAS Build APK**: Now uses `app-version` (e.g., "tractor-v1.0.0.apk") for OTA-compatible filenames

## Test plan
- [ ] Verify EAS Update workflow uses correct version output reference
- [ ] Verify EAS Build APK workflow generates correctly named APK files
- [ ] Confirm workflows don't fail due to missing version output references

🤖 Generated with [Claude Code](https://claude.ai/code)