### PR TITLE
fix: inject dynamic channel name for beta updates

### DIFF
--- a/.github/actions/git-version/action.yml
+++ b/.github/actions/git-version/action.yml
@@ -95,6 +95,6 @@ runs:
     - name: Inject version into app.json
       shell: bash
       run: |
-        jq '.expo.version = "${{ steps.detect.outputs.app-version }}" | .expo.extra.version = "${{ steps.detect.outputs.full-version }}"' app.json > app.json.tmp
+        jq '.expo.version = "${{ steps.detect.outputs.app-version }}" | .expo.extra.version = "${{ steps.detect.outputs.full-version }}" | .expo.updates.requestHeaders."expo-channel-name" = "${{ steps.detect.outputs.eas-branch }}"' app.json > app.json.tmp
         mv app.json.tmp app.json
-        echo "Injected app version ${{ steps.detect.outputs.app-version }} and full version ${{ steps.detect.outputs.full-version }} into app.json"
+        echo "Injected app version ${{ steps.detect.outputs.app-version }}, full version ${{ steps.detect.outputs.full-version }}, and channel ${{ steps.detect.outputs.eas-branch }} into app.json"


### PR DESCRIPTION
## Summary
- Fixes the issue where beta updates couldn't be loaded in Expo Go
- Updates git-version action to inject correct `expo-channel-name` based on deployment branch
- Dynamically sets channel name: beta/production/alpha instead of hardcoded "production"

## Root Cause
The app.json was hardcoded with `"expo-channel-name": "production"`, but beta updates were published to the `beta` channel. This caused a channel mismatch preventing Expo Go from loading beta updates.

## Solution
Git-version action now injects the correct channel name during deployment:
- Beta builds → `"expo-channel-name": "beta"`
- Production builds → `"expo-channel-name": "production"`  
- Alpha builds → `"expo-channel-name": "alpha"`

## Test plan
- [ ] Merge and trigger new beta update
- [ ] Verify beta updates load correctly in Expo Go
- [ ] Test both direct URL and project list methods

🤖 Generated with [Claude Code](https://claude.ai/code)