### PR TITLE
fix: resolve VersionDisplay splash screen hang in EAS updates

### DIFF
--- a/beta-5.json
+++ b/beta-5.json
@@ -1,0 +1,564 @@
+{
+  "updatesByGroup": [
+    {
+      "id": "515f5a61-93d6-437f-94f6-5dd205f3edc1",
+      "group": "aac1e6bc-7b88-4505-acc1-23c4492d6f3a",
+      "message": "Release v1.1.0-beta.5+9789781",
+      "createdAt": "2025-06-06T23:53:12.326Z",
+      "updatedAt": "2025-06-06T23:53:12.326Z",
+      "isRollBackToEmbedded": false,
+      "codeSigningInfo": null,
+      "runtime": "v1.1.0-beta.5+9789781",
+      "platform": "ios",
+      "gitCommitHash": "97897816ab1908baaf1223fc77889fba574eb1ab",
+      "isGitWorkingTreeDirty": true,
+      "manifestFragment": {
+        "extra": {
+          "expoClient": {
+            "ios": {
+              "supportsTablet": true
+            },
+            "icon": "./assets/images/icon.png",
+            "name": "Tractor",
+            "slug": "Tractor",
+            "extra": {
+              "eas": {
+                "projectId": "3256dcee-103a-467b-96c4-97a9f634df51"
+              },
+              "router": {},
+              "version": "v1.1.0-beta.5+9789781",
+              "gitCommit": "97897816ab1908baaf1223fc77889fba574eb1ab"
+            },
+            "owner": "ericvan76",
+            "scheme": "tractor",
+            "android": {
+              "package": "com.cardgame.tractor",
+              "permissions": [
+                "android.permission.VIBRATE"
+              ],
+              "versionCode": 1,
+              "adaptiveIcon": {
+                "backgroundColor": "#0F4A3C",
+                "foregroundImage": "./assets/images/adaptive-icon.png"
+              },
+              "edgeToEdgeEnabled": true,
+              "softwareKeyboardLayoutMode": "pan"
+            },
+            "plugins": [
+              "expo-router",
+              [
+                "expo-splash-screen",
+                {
+                  "image": "./assets/images/splash-icon.png",
+                  "imageWidth": 250,
+                  "resizeMode": "contain",
+                  "backgroundColor": "#0A3A2E"
+                }
+              ]
+            ],
+            "updates": {
+              "url": "https://u.expo.dev/3256dcee-103a-467b-96c4-97a9f634df51",
+              "requestHeaders": {
+                "expo-channel-name": "production"
+              },
+              "fallbackToCacheTimeout": 0
+            },
+            "version": "v1.1.0-beta.5+9789781",
+            "jsEngine": "hermes",
+            "platforms": [
+              "ios",
+              "android"
+            ],
+            "sdkVersion": "53.0.0",
+            "experiments": {
+              "typedRoutes": true
+            },
+            "orientation": "portrait",
+            "newArchEnabled": true,
+            "runtimeVersion": {
+              "policy": "appVersion"
+            },
+            "androidStatusBar": {
+              "backgroundColor": "#0A3A2E"
+            },
+            "userInterfaceStyle": "automatic",
+            "assetBundlePatterns": [
+              "**/*"
+            ]
+          }
+        },
+        "assets": [
+          {
+            "bundleKey": "7d40544b395c5949f4646f5e150fe020",
+            "fileSHA256": "LN_rjlzN55dvcBL7jM5zryIpAp7iHU8VCf7RFIccbNg",
+            "storageKey": "Pi65ns2w9xLI5G_m9aGrJ5wK5FpWcGcInSSFwnA_0aA",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "a132ecc4ba5c1517ff83c0fb321bc7fc",
+            "fileSHA256": "K3RDqaWOksoRpXW9wRWYYVpX3eMFzYznDWAmBrMCzZg",
+            "storageKey": "X3OAkUu5P_LqyKFx1bNkA_qDQFLlSjCYNAlVEaOamHE",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "0ea69b5077e7c4696db85dbcba75b0e1",
+            "fileSHA256": "Pd0Hc-0n4j0leJ8wFzGzrEVa2L5aonoKG4OPicbSciU",
+            "storageKey": "FwJkAbrRNahBGX1KXnTAgiiwyzENu3D7DeEzCwmInyo",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "2d0a9133e39524f138be6d4db9f4851f",
+            "fileSHA256": "ku2BdqyMtENipfxqNwNiagAGrGt8snLumfWFAmLsBw4",
+            "storageKey": "I8dvryp2TLXxE9DKqjCm2NN54-HfFCrFNcg8F_7LXJA",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "0a328cd9c1afd0afe8e3b1ec5165b1b4",
+            "fileSHA256": "mtuMXvypMuK3MrKT2oE70uMZUiYwVrzp4lF_7A8LanY",
+            "storageKey": "LM4SxB4vhDe2iN4tYT0dAlPP_dsY-Zme_H-JpULtHa8",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "3cd68ccdb8938e3711da2e8831b85493",
+            "fileSHA256": "yGu0he7mh-BsUA_EI09RpnhLRTDCrhHQx2SBEQvOMQU",
+            "storageKey": "A08F4i_QzJW79C3BCIZYmmpH_p2FkQbdTQZ_2hVWDeg",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "61ca7e64b7d605716c57706cef640b9a",
+            "fileSHA256": "0Dpc16Zu8QxRR5FvnVh4stCgpa1G9AWjHNmWfvqlWv0",
+            "storageKey": "04lOdmTXc1loPyqacYwao1j0xlM34n0vGxtIFY7ETTs",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "aff2c65b39a296d4f7e96d0f58169170",
+            "fileSHA256": "q1YT0s5w-mfFkm6DE1NmSUUZn8GV-m_nbF_jzsRS4xo",
+            "storageKey": "4s0taS6e9_zozzhgsa6FogUB4b0LQc1LMNbBLkxlIz0",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "d8e7601e3df962f83c62371ac14964d8",
+            "fileSHA256": "xOVOagp95jaqFTN4-8YupKQWlb_t-Af5Dfexj_1zP2c",
+            "storageKey": "g6PisuFJa8j79kTi3ZKboB3DcerIBZXujlFBVhXkh1s",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "3cd68ccdb8938e3711da2e8831b85493",
+            "fileSHA256": "yGu0he7mh-BsUA_EI09RpnhLRTDCrhHQx2SBEQvOMQU",
+            "storageKey": "A08F4i_QzJW79C3BCIZYmmpH_p2FkQbdTQZ_2hVWDeg",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "0747a1317bbe9c6fc340b889ef8ab3ae",
+            "fileSHA256": "IyXFOnPlTEOMu8YN_92LUT1HG6QuL1ZxPvQEuV4Mofw",
+            "storageKey": "DP7IegcRXP-7kIHiKmplB43A2HIM9nT01_O4JsXZKXI",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "d84e297c3b3e49a614248143d53e40ca",
+            "fileSHA256": "sbwYEMoj4sOM12lxxDWR1yYWEGEkDYt5KwV1cZbdtSg",
+            "storageKey": "aY8TciqT0pLONlgDC1iSLgQd6TyRf7NkBhUrJkfuqD0",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "1190ab078c57159f4245a328118fcd9a",
+            "fileSHA256": "y9-SE-VfZcSNB2rNhCO3ya7k8bgRAf9slaOMTNioZGE",
+            "storageKey": "mJsf9KoBQiKLAHO11XdSt59xshQZeDJmGEa9jlA_GY4",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "78c625386b4d0690b421eb0fc78f7b9c",
+            "fileSHA256": "0FydMNefRaeOVYWi5-xnxqBqiD3ZE34dUFnoyHszznY",
+            "storageKey": "yag9GLD2iZjnBBRuIa9kgMTdG2sabQ7v5K3JoDYQcqY",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "0747a1317bbe9c6fc340b889ef8ab3ae",
+            "fileSHA256": "IyXFOnPlTEOMu8YN_92LUT1HG6QuL1ZxPvQEuV4Mofw",
+            "storageKey": "DP7IegcRXP-7kIHiKmplB43A2HIM9nT01_O4JsXZKXI",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "dad2fa9f4394a630f0f9a0d6dabd44bc",
+            "fileSHA256": "3Fa5dr1FY44RJfZol0NSXmiGrgvvLI9GUZlIM2hagx8",
+            "storageKey": "dKG-AjtNeel2LjkGsDkmnWB4pQbGddnfBSLVF8WMiZo",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "f3a81967828232c893d547162e922764",
+            "fileSHA256": "7xP8DfxS7COBdYX9fhCfvfWTo7JUnEDOcaybDtoSzCw",
+            "storageKey": "YwOPYZk6RzR-yqrSLnzNa9-a6jKqlFcZk7-CyykA42Y",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "d62ddc38b69aff346c20a28774933d6a",
+            "fileSHA256": "tDSnzxjC1M50fHCULqL-4tRBLZOWftkrNy-BC7kmHqU",
+            "storageKey": "uQY2IIL89sZpR_V6aLXhWoTtqSVXfWkY_P-nNyiRUyE",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "f3a81967828232c893d547162e922764",
+            "fileSHA256": "7xP8DfxS7COBdYX9fhCfvfWTo7JUnEDOcaybDtoSzCw",
+            "storageKey": "YwOPYZk6RzR-yqrSLnzNa9-a6jKqlFcZk7-CyykA42Y",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "d1ea1496f9057eb392d5bbf3732a61b7",
+            "fileSHA256": "wV7HKnTROVchGAgxPVw13rf3YGxtItvdzrAADU4FR60",
+            "storageKey": "iiX0QENtWnFHr-ql_G75Cv2aoG8T9jbnoTrrLiduBMs",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "19eeb73b9593a38f8e9f418337fc7d10",
+            "fileSHA256": "ppou21tsYLhDPVttI8afUgzNimAvP2DnmW5Ilxi8F1w",
+            "storageKey": "0OEDV0a6nXu3m-NCyMZCejvRaLMgUJoN5kZZr6WGO9o",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "ab19f4cbc543357183a20571f68380a3",
+            "fileSHA256": "J_TSKdRAklv3IS1d__pF1Zayx7O7KQXJa4ObIIGh2-s",
+            "storageKey": "1QHSPNPuPJBWsSu-NeGsZJ65lgP9Nn9hUrFpSvorJ3Y",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "d8b800c443b8972542883e0b9de2bdc6",
+            "fileSHA256": "cIp5z1YbiipIUM4CVFhNOlIxBGvgj7f630tu39sxF4s",
+            "storageKey": "F0VhhOdSAZAGWHzCBT8frAxWVDzVgNYGLlSTnInMLk0",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "412dd9275b6b48ad28f5e3d81bb1f626",
+            "fileSHA256": "rPaRlXo7zOfRlYVtzpilzxTc4QvqKKpcELNVDAeOI7U",
+            "storageKey": "YbOaNgsSGzVwiIMg8au7XcXF5nhp0mKG64zufThcPZQ",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "20e71bdf79e3a97bf55fd9e164041578",
+            "fileSHA256": "78edo8TJffsVcb_2IClYqwUpxaox6DkmAFeLPjWdFEc",
+            "storageKey": "Ij5rVfQl_Hbg8xU1LXrdNRR__q6WTEE-FIneYIROiLQ",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "49a79d66bdea2debf1832bf4d7aca127",
+            "fileSHA256": "TDIlFNJlBiqj9_vYH1t5ORzLdCaOaiBgAGHgzjMjT0E",
+            "storageKey": "dmOaC6Uf95Cn4adL7UKjKsEcVkQ_ma4sXIuHYa9gadQ",
+            "contentType": "font/ttf",
+            "fileExtension": ".ttf"
+          }
+        ],
+        "launchAsset": {
+          "bundleKey": "5cc7d519e6729618cf28871e49ff7ad5",
+          "fileSHA256": "6y5vDbc5YrpQ5DIu5n3YNoFaU_r7_lRn9Qb7detpYrU",
+          "storageKey": "A-MYZNTMos4BWicbSfuqiJHV4q5M96ZqvIQLSJRUfZU",
+          "contentType": "application/javascript",
+          "fileExtension": ".hbc"
+        }
+      }
+    },
+    {
+      "id": "d3c6667d-e4a7-4888-ab0f-9eff16031109",
+      "group": "aac1e6bc-7b88-4505-acc1-23c4492d6f3a",
+      "message": "Release v1.1.0-beta.5+9789781",
+      "createdAt": "2025-06-06T23:53:12.326Z",
+      "updatedAt": "2025-06-06T23:53:12.326Z",
+      "isRollBackToEmbedded": false,
+      "codeSigningInfo": null,
+      "runtime": "v1.1.0-beta.5+9789781",
+      "platform": "android",
+      "gitCommitHash": "97897816ab1908baaf1223fc77889fba574eb1ab",
+      "isGitWorkingTreeDirty": true,
+      "manifestFragment": {
+        "extra": {
+          "expoClient": {
+            "ios": {
+              "supportsTablet": true
+            },
+            "icon": "./assets/images/icon.png",
+            "name": "Tractor",
+            "slug": "Tractor",
+            "extra": {
+              "eas": {
+                "projectId": "3256dcee-103a-467b-96c4-97a9f634df51"
+              },
+              "router": {},
+              "version": "v1.1.0-beta.5+9789781",
+              "gitCommit": "97897816ab1908baaf1223fc77889fba574eb1ab"
+            },
+            "owner": "ericvan76",
+            "scheme": "tractor",
+            "android": {
+              "package": "com.cardgame.tractor",
+              "permissions": [
+                "android.permission.VIBRATE"
+              ],
+              "versionCode": 1,
+              "adaptiveIcon": {
+                "backgroundColor": "#0F4A3C",
+                "foregroundImage": "./assets/images/adaptive-icon.png"
+              },
+              "edgeToEdgeEnabled": true,
+              "softwareKeyboardLayoutMode": "pan"
+            },
+            "plugins": [
+              "expo-router",
+              [
+                "expo-splash-screen",
+                {
+                  "image": "./assets/images/splash-icon.png",
+                  "imageWidth": 250,
+                  "resizeMode": "contain",
+                  "backgroundColor": "#0A3A2E"
+                }
+              ]
+            ],
+            "updates": {
+              "url": "https://u.expo.dev/3256dcee-103a-467b-96c4-97a9f634df51",
+              "requestHeaders": {
+                "expo-channel-name": "production"
+              },
+              "fallbackToCacheTimeout": 0
+            },
+            "version": "v1.1.0-beta.5+9789781",
+            "jsEngine": "hermes",
+            "platforms": [
+              "ios",
+              "android"
+            ],
+            "sdkVersion": "53.0.0",
+            "experiments": {
+              "typedRoutes": true
+            },
+            "orientation": "portrait",
+            "newArchEnabled": true,
+            "runtimeVersion": {
+              "policy": "appVersion"
+            },
+            "androidStatusBar": {
+              "backgroundColor": "#0A3A2E"
+            },
+            "userInterfaceStyle": "automatic",
+            "assetBundlePatterns": [
+              "**/*"
+            ]
+          }
+        },
+        "assets": [
+          {
+            "bundleKey": "778ffc9fe8773a878e9c30a6304784de",
+            "fileSHA256": "i2Gkx-9w3JJ1PwSUl2SC9m_UFQ7CPfx3KrZeEDc6-lU",
+            "storageKey": "idnX8z03q4vGLzhYMPaQGBADjhqvWe67_afPqJ1vGzM",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "c79c3606a1cf168006ad3979763c7e0c",
+            "fileSHA256": "kGZm3WiTRq2iMs42ia3vkHtCV_obWT8DY40rlJf2SIQ",
+            "storageKey": "k-3xHp3vP8mR36WdccUZVPTRJKpP-zlyboWdkXCIQpQ",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "02bc1fa7c0313217bde2d65ccbff40c9",
+            "fileSHA256": "_6fuRbdkBbpzkhSVAI99aMneY5X0tpQdsGNGX244IyA",
+            "storageKey": "lfqeUjiWFXwowhxVDBEzxsbTOEzYxMLebljy5Bh1mpU",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "35ba0eaec5a4f5ed12ca16fabeae451d",
+            "fileSHA256": "hM9es7ICUPaeDkczvrTaX0F_BoKJKlrRteYlcHU8IbE",
+            "storageKey": "fMoMrsUeB5xWw_Ugn8FqGJf-M2pld2hkXKR704z0MM8",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "0a328cd9c1afd0afe8e3b1ec5165b1b4",
+            "fileSHA256": "mtuMXvypMuK3MrKT2oE70uMZUiYwVrzp4lF_7A8LanY",
+            "storageKey": "LM4SxB4vhDe2iN4tYT0dAlPP_dsY-Zme_H-JpULtHa8",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "3cd68ccdb8938e3711da2e8831b85493",
+            "fileSHA256": "yGu0he7mh-BsUA_EI09RpnhLRTDCrhHQx2SBEQvOMQU",
+            "storageKey": "A08F4i_QzJW79C3BCIZYmmpH_p2FkQbdTQZ_2hVWDeg",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "61ca7e64b7d605716c57706cef640b9a",
+            "fileSHA256": "0Dpc16Zu8QxRR5FvnVh4stCgpa1G9AWjHNmWfvqlWv0",
+            "storageKey": "04lOdmTXc1loPyqacYwao1j0xlM34n0vGxtIFY7ETTs",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "aff2c65b39a296d4f7e96d0f58169170",
+            "fileSHA256": "q1YT0s5w-mfFkm6DE1NmSUUZn8GV-m_nbF_jzsRS4xo",
+            "storageKey": "4s0taS6e9_zozzhgsa6FogUB4b0LQc1LMNbBLkxlIz0",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "d8e7601e3df962f83c62371ac14964d8",
+            "fileSHA256": "xOVOagp95jaqFTN4-8YupKQWlb_t-Af5Dfexj_1zP2c",
+            "storageKey": "g6PisuFJa8j79kTi3ZKboB3DcerIBZXujlFBVhXkh1s",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "3cd68ccdb8938e3711da2e8831b85493",
+            "fileSHA256": "yGu0he7mh-BsUA_EI09RpnhLRTDCrhHQx2SBEQvOMQU",
+            "storageKey": "A08F4i_QzJW79C3BCIZYmmpH_p2FkQbdTQZ_2hVWDeg",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "0747a1317bbe9c6fc340b889ef8ab3ae",
+            "fileSHA256": "IyXFOnPlTEOMu8YN_92LUT1HG6QuL1ZxPvQEuV4Mofw",
+            "storageKey": "DP7IegcRXP-7kIHiKmplB43A2HIM9nT01_O4JsXZKXI",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "d84e297c3b3e49a614248143d53e40ca",
+            "fileSHA256": "sbwYEMoj4sOM12lxxDWR1yYWEGEkDYt5KwV1cZbdtSg",
+            "storageKey": "aY8TciqT0pLONlgDC1iSLgQd6TyRf7NkBhUrJkfuqD0",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "1190ab078c57159f4245a328118fcd9a",
+            "fileSHA256": "y9-SE-VfZcSNB2rNhCO3ya7k8bgRAf9slaOMTNioZGE",
+            "storageKey": "mJsf9KoBQiKLAHO11XdSt59xshQZeDJmGEa9jlA_GY4",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "78c625386b4d0690b421eb0fc78f7b9c",
+            "fileSHA256": "0FydMNefRaeOVYWi5-xnxqBqiD3ZE34dUFnoyHszznY",
+            "storageKey": "yag9GLD2iZjnBBRuIa9kgMTdG2sabQ7v5K3JoDYQcqY",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "0747a1317bbe9c6fc340b889ef8ab3ae",
+            "fileSHA256": "IyXFOnPlTEOMu8YN_92LUT1HG6QuL1ZxPvQEuV4Mofw",
+            "storageKey": "DP7IegcRXP-7kIHiKmplB43A2HIM9nT01_O4JsXZKXI",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "4403c6117ec30c859bc95d70ce4a71d3",
+            "fileSHA256": "unIvskv_CkxS5lbN8gXerFxd-F5briv20wcTvVDG1fc",
+            "storageKey": "uG5CihBixNlPMeYN0V5MRwARA2Ovn0seNtMvhelV3kE",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "069d99eb1fa6712c0b9034a58c6b57dd",
+            "fileSHA256": "UwD1C-NlnRfYzuho7E5sDT9OiZRP1YmdPCD2p2egRfU",
+            "storageKey": "dV5iuhAavksqtDhoNxjh3ZJ3mjhWaRm_k_QMsxTkJRg",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "c3273c9e5321f20d1e42c2efae2578c4",
+            "fileSHA256": "bI8Rv9HH4idp3BNcFuzQ4FO7VVVNqIuWEdnPcdEhNvE",
+            "storageKey": "r81JaSP6EG6dxkyPe8l7CAVizX4cmddQVze71LebmUo",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "286d67d3f74808a60a78d3ebf1a5fb57",
+            "fileSHA256": "XQdeDCh8T0RBtbXI_H6lzSfBG7YX7OoJdVlVvLGIkIM",
+            "storageKey": "m9yS4VLFfdQtO3uDS8O8dWqyH7JfIBfBd3VkPnFGw6c",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "d1ea1496f9057eb392d5bbf3732a61b7",
+            "fileSHA256": "wV7HKnTROVchGAgxPVw13rf3YGxtItvdzrAADU4FR60",
+            "storageKey": "iiX0QENtWnFHr-ql_G75Cv2aoG8T9jbnoTrrLiduBMs",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "19eeb73b9593a38f8e9f418337fc7d10",
+            "fileSHA256": "ppou21tsYLhDPVttI8afUgzNimAvP2DnmW5Ilxi8F1w",
+            "storageKey": "0OEDV0a6nXu3m-NCyMZCejvRaLMgUJoN5kZZr6WGO9o",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "ab19f4cbc543357183a20571f68380a3",
+            "fileSHA256": "J_TSKdRAklv3IS1d__pF1Zayx7O7KQXJa4ObIIGh2-s",
+            "storageKey": "1QHSPNPuPJBWsSu-NeGsZJ65lgP9Nn9hUrFpSvorJ3Y",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "d8b800c443b8972542883e0b9de2bdc6",
+            "fileSHA256": "cIp5z1YbiipIUM4CVFhNOlIxBGvgj7f630tu39sxF4s",
+            "storageKey": "F0VhhOdSAZAGWHzCBT8frAxWVDzVgNYGLlSTnInMLk0",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "412dd9275b6b48ad28f5e3d81bb1f626",
+            "fileSHA256": "rPaRlXo7zOfRlYVtzpilzxTc4QvqKKpcELNVDAeOI7U",
+            "storageKey": "YbOaNgsSGzVwiIMg8au7XcXF5nhp0mKG64zufThcPZQ",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "20e71bdf79e3a97bf55fd9e164041578",
+            "fileSHA256": "78edo8TJffsVcb_2IClYqwUpxaox6DkmAFeLPjWdFEc",
+            "storageKey": "Ij5rVfQl_Hbg8xU1LXrdNRR__q6WTEE-FIneYIROiLQ",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "49a79d66bdea2debf1832bf4d7aca127",
+            "fileSHA256": "TDIlFNJlBiqj9_vYH1t5ORzLdCaOaiBgAGHgzjMjT0E",
+            "storageKey": "dmOaC6Uf95Cn4adL7UKjKsEcVkQ_ma4sXIuHYa9gadQ",
+            "contentType": "font/ttf",
+            "fileExtension": ".ttf"
+          }
+        ],
+        "launchAsset": {
+          "bundleKey": "21ae14e49f5252d5a21421405a8a5932",
+          "fileSHA256": "9s44wRM3HzNLgXbcYXXTB1wN9CbkqFprCVCuoIUrNms",
+          "storageKey": "eyA5MLo0xnk5vnmlw2h9BJChVlJGFKEXko_xCgEl3ls",
+          "contentType": "application/javascript",
+          "fileExtension": ".hbc"
+        }
+      }
+    }
+  ]
+}

--- a/beta-7.json
+++ b/beta-7.json
@@ -1,0 +1,562 @@
+{
+  "updatesByGroup": [
+    {
+      "id": "a7528fb1-f9a9-4446-a58e-e48f8b54c517",
+      "group": "b8e85756-4f3b-49d6-bc73-8178fe809c38",
+      "message": "Update v1.1.0-beta.7+bdc9638",
+      "createdAt": "2025-06-07T02:01:56.264Z",
+      "updatedAt": "2025-06-07T02:01:56.264Z",
+      "isRollBackToEmbedded": false,
+      "codeSigningInfo": null,
+      "runtime": "v1.1.0-beta.7",
+      "platform": "ios",
+      "gitCommitHash": "bdc9638168dcb42264cc31678f636e43fbf43746",
+      "isGitWorkingTreeDirty": true,
+      "manifestFragment": {
+        "extra": {
+          "expoClient": {
+            "ios": {
+              "supportsTablet": true
+            },
+            "icon": "./assets/images/icon.png",
+            "name": "Tractor",
+            "slug": "Tractor",
+            "extra": {
+              "eas": {
+                "projectId": "3256dcee-103a-467b-96c4-97a9f634df51"
+              },
+              "router": {},
+              "version": "v1.1.0-beta.7+bdc9638"
+            },
+            "owner": "ericvan76",
+            "scheme": "tractor",
+            "android": {
+              "package": "com.cardgame.tractor",
+              "permissions": [
+                "android.permission.VIBRATE"
+              ],
+              "versionCode": 1,
+              "adaptiveIcon": {
+                "backgroundColor": "#0F4A3C",
+                "foregroundImage": "./assets/images/adaptive-icon.png"
+              },
+              "edgeToEdgeEnabled": true,
+              "softwareKeyboardLayoutMode": "pan"
+            },
+            "plugins": [
+              "expo-router",
+              [
+                "expo-splash-screen",
+                {
+                  "image": "./assets/images/splash-icon.png",
+                  "imageWidth": 250,
+                  "resizeMode": "contain",
+                  "backgroundColor": "#0A3A2E"
+                }
+              ]
+            ],
+            "updates": {
+              "url": "https://u.expo.dev/3256dcee-103a-467b-96c4-97a9f634df51",
+              "requestHeaders": {
+                "expo-channel-name": "production"
+              },
+              "fallbackToCacheTimeout": 0
+            },
+            "version": "v1.1.0-beta.7",
+            "jsEngine": "hermes",
+            "platforms": [
+              "ios",
+              "android"
+            ],
+            "sdkVersion": "53.0.0",
+            "experiments": {
+              "typedRoutes": true
+            },
+            "orientation": "portrait",
+            "newArchEnabled": true,
+            "runtimeVersion": {
+              "policy": "appVersion"
+            },
+            "androidStatusBar": {
+              "backgroundColor": "#0A3A2E"
+            },
+            "userInterfaceStyle": "automatic",
+            "assetBundlePatterns": [
+              "**/*"
+            ]
+          }
+        },
+        "assets": [
+          {
+            "bundleKey": "7d40544b395c5949f4646f5e150fe020",
+            "fileSHA256": "LN_rjlzN55dvcBL7jM5zryIpAp7iHU8VCf7RFIccbNg",
+            "storageKey": "Pi65ns2w9xLI5G_m9aGrJ5wK5FpWcGcInSSFwnA_0aA",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "a132ecc4ba5c1517ff83c0fb321bc7fc",
+            "fileSHA256": "K3RDqaWOksoRpXW9wRWYYVpX3eMFzYznDWAmBrMCzZg",
+            "storageKey": "X3OAkUu5P_LqyKFx1bNkA_qDQFLlSjCYNAlVEaOamHE",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "0ea69b5077e7c4696db85dbcba75b0e1",
+            "fileSHA256": "Pd0Hc-0n4j0leJ8wFzGzrEVa2L5aonoKG4OPicbSciU",
+            "storageKey": "FwJkAbrRNahBGX1KXnTAgiiwyzENu3D7DeEzCwmInyo",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "2d0a9133e39524f138be6d4db9f4851f",
+            "fileSHA256": "ku2BdqyMtENipfxqNwNiagAGrGt8snLumfWFAmLsBw4",
+            "storageKey": "I8dvryp2TLXxE9DKqjCm2NN54-HfFCrFNcg8F_7LXJA",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "0a328cd9c1afd0afe8e3b1ec5165b1b4",
+            "fileSHA256": "mtuMXvypMuK3MrKT2oE70uMZUiYwVrzp4lF_7A8LanY",
+            "storageKey": "LM4SxB4vhDe2iN4tYT0dAlPP_dsY-Zme_H-JpULtHa8",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "3cd68ccdb8938e3711da2e8831b85493",
+            "fileSHA256": "yGu0he7mh-BsUA_EI09RpnhLRTDCrhHQx2SBEQvOMQU",
+            "storageKey": "A08F4i_QzJW79C3BCIZYmmpH_p2FkQbdTQZ_2hVWDeg",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "61ca7e64b7d605716c57706cef640b9a",
+            "fileSHA256": "0Dpc16Zu8QxRR5FvnVh4stCgpa1G9AWjHNmWfvqlWv0",
+            "storageKey": "04lOdmTXc1loPyqacYwao1j0xlM34n0vGxtIFY7ETTs",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "aff2c65b39a296d4f7e96d0f58169170",
+            "fileSHA256": "q1YT0s5w-mfFkm6DE1NmSUUZn8GV-m_nbF_jzsRS4xo",
+            "storageKey": "4s0taS6e9_zozzhgsa6FogUB4b0LQc1LMNbBLkxlIz0",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "d8e7601e3df962f83c62371ac14964d8",
+            "fileSHA256": "xOVOagp95jaqFTN4-8YupKQWlb_t-Af5Dfexj_1zP2c",
+            "storageKey": "g6PisuFJa8j79kTi3ZKboB3DcerIBZXujlFBVhXkh1s",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "3cd68ccdb8938e3711da2e8831b85493",
+            "fileSHA256": "yGu0he7mh-BsUA_EI09RpnhLRTDCrhHQx2SBEQvOMQU",
+            "storageKey": "A08F4i_QzJW79C3BCIZYmmpH_p2FkQbdTQZ_2hVWDeg",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "0747a1317bbe9c6fc340b889ef8ab3ae",
+            "fileSHA256": "IyXFOnPlTEOMu8YN_92LUT1HG6QuL1ZxPvQEuV4Mofw",
+            "storageKey": "DP7IegcRXP-7kIHiKmplB43A2HIM9nT01_O4JsXZKXI",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "d84e297c3b3e49a614248143d53e40ca",
+            "fileSHA256": "sbwYEMoj4sOM12lxxDWR1yYWEGEkDYt5KwV1cZbdtSg",
+            "storageKey": "aY8TciqT0pLONlgDC1iSLgQd6TyRf7NkBhUrJkfuqD0",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "1190ab078c57159f4245a328118fcd9a",
+            "fileSHA256": "y9-SE-VfZcSNB2rNhCO3ya7k8bgRAf9slaOMTNioZGE",
+            "storageKey": "mJsf9KoBQiKLAHO11XdSt59xshQZeDJmGEa9jlA_GY4",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "78c625386b4d0690b421eb0fc78f7b9c",
+            "fileSHA256": "0FydMNefRaeOVYWi5-xnxqBqiD3ZE34dUFnoyHszznY",
+            "storageKey": "yag9GLD2iZjnBBRuIa9kgMTdG2sabQ7v5K3JoDYQcqY",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "0747a1317bbe9c6fc340b889ef8ab3ae",
+            "fileSHA256": "IyXFOnPlTEOMu8YN_92LUT1HG6QuL1ZxPvQEuV4Mofw",
+            "storageKey": "DP7IegcRXP-7kIHiKmplB43A2HIM9nT01_O4JsXZKXI",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "dad2fa9f4394a630f0f9a0d6dabd44bc",
+            "fileSHA256": "3Fa5dr1FY44RJfZol0NSXmiGrgvvLI9GUZlIM2hagx8",
+            "storageKey": "dKG-AjtNeel2LjkGsDkmnWB4pQbGddnfBSLVF8WMiZo",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "f3a81967828232c893d547162e922764",
+            "fileSHA256": "7xP8DfxS7COBdYX9fhCfvfWTo7JUnEDOcaybDtoSzCw",
+            "storageKey": "YwOPYZk6RzR-yqrSLnzNa9-a6jKqlFcZk7-CyykA42Y",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "d62ddc38b69aff346c20a28774933d6a",
+            "fileSHA256": "tDSnzxjC1M50fHCULqL-4tRBLZOWftkrNy-BC7kmHqU",
+            "storageKey": "uQY2IIL89sZpR_V6aLXhWoTtqSVXfWkY_P-nNyiRUyE",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "f3a81967828232c893d547162e922764",
+            "fileSHA256": "7xP8DfxS7COBdYX9fhCfvfWTo7JUnEDOcaybDtoSzCw",
+            "storageKey": "YwOPYZk6RzR-yqrSLnzNa9-a6jKqlFcZk7-CyykA42Y",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "d1ea1496f9057eb392d5bbf3732a61b7",
+            "fileSHA256": "wV7HKnTROVchGAgxPVw13rf3YGxtItvdzrAADU4FR60",
+            "storageKey": "iiX0QENtWnFHr-ql_G75Cv2aoG8T9jbnoTrrLiduBMs",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "19eeb73b9593a38f8e9f418337fc7d10",
+            "fileSHA256": "ppou21tsYLhDPVttI8afUgzNimAvP2DnmW5Ilxi8F1w",
+            "storageKey": "0OEDV0a6nXu3m-NCyMZCejvRaLMgUJoN5kZZr6WGO9o",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "ab19f4cbc543357183a20571f68380a3",
+            "fileSHA256": "J_TSKdRAklv3IS1d__pF1Zayx7O7KQXJa4ObIIGh2-s",
+            "storageKey": "1QHSPNPuPJBWsSu-NeGsZJ65lgP9Nn9hUrFpSvorJ3Y",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "d8b800c443b8972542883e0b9de2bdc6",
+            "fileSHA256": "cIp5z1YbiipIUM4CVFhNOlIxBGvgj7f630tu39sxF4s",
+            "storageKey": "F0VhhOdSAZAGWHzCBT8frAxWVDzVgNYGLlSTnInMLk0",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "412dd9275b6b48ad28f5e3d81bb1f626",
+            "fileSHA256": "rPaRlXo7zOfRlYVtzpilzxTc4QvqKKpcELNVDAeOI7U",
+            "storageKey": "YbOaNgsSGzVwiIMg8au7XcXF5nhp0mKG64zufThcPZQ",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "20e71bdf79e3a97bf55fd9e164041578",
+            "fileSHA256": "78edo8TJffsVcb_2IClYqwUpxaox6DkmAFeLPjWdFEc",
+            "storageKey": "Ij5rVfQl_Hbg8xU1LXrdNRR__q6WTEE-FIneYIROiLQ",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "49a79d66bdea2debf1832bf4d7aca127",
+            "fileSHA256": "TDIlFNJlBiqj9_vYH1t5ORzLdCaOaiBgAGHgzjMjT0E",
+            "storageKey": "dmOaC6Uf95Cn4adL7UKjKsEcVkQ_ma4sXIuHYa9gadQ",
+            "contentType": "font/ttf",
+            "fileExtension": ".ttf"
+          }
+        ],
+        "launchAsset": {
+          "bundleKey": "b22aced009d061a4d6fe84f03788d92a",
+          "fileSHA256": "gXrVyU75VVKHGJJgtMA4boR5cgje0WLjvT0aG6IqoEo",
+          "storageKey": "NOx-UU1ZVnGFTF5zdZyO_Dt1SS6j0VnuwWbLnyUH4y4",
+          "contentType": "application/javascript",
+          "fileExtension": ".hbc"
+        }
+      }
+    },
+    {
+      "id": "39965547-f734-4a56-af22-163ff4ed008a",
+      "group": "b8e85756-4f3b-49d6-bc73-8178fe809c38",
+      "message": "Update v1.1.0-beta.7+bdc9638",
+      "createdAt": "2025-06-07T02:01:56.264Z",
+      "updatedAt": "2025-06-07T02:01:56.264Z",
+      "isRollBackToEmbedded": false,
+      "codeSigningInfo": null,
+      "runtime": "v1.1.0-beta.7",
+      "platform": "android",
+      "gitCommitHash": "bdc9638168dcb42264cc31678f636e43fbf43746",
+      "isGitWorkingTreeDirty": true,
+      "manifestFragment": {
+        "extra": {
+          "expoClient": {
+            "ios": {
+              "supportsTablet": true
+            },
+            "icon": "./assets/images/icon.png",
+            "name": "Tractor",
+            "slug": "Tractor",
+            "extra": {
+              "eas": {
+                "projectId": "3256dcee-103a-467b-96c4-97a9f634df51"
+              },
+              "router": {},
+              "version": "v1.1.0-beta.7+bdc9638"
+            },
+            "owner": "ericvan76",
+            "scheme": "tractor",
+            "android": {
+              "package": "com.cardgame.tractor",
+              "permissions": [
+                "android.permission.VIBRATE"
+              ],
+              "versionCode": 1,
+              "adaptiveIcon": {
+                "backgroundColor": "#0F4A3C",
+                "foregroundImage": "./assets/images/adaptive-icon.png"
+              },
+              "edgeToEdgeEnabled": true,
+              "softwareKeyboardLayoutMode": "pan"
+            },
+            "plugins": [
+              "expo-router",
+              [
+                "expo-splash-screen",
+                {
+                  "image": "./assets/images/splash-icon.png",
+                  "imageWidth": 250,
+                  "resizeMode": "contain",
+                  "backgroundColor": "#0A3A2E"
+                }
+              ]
+            ],
+            "updates": {
+              "url": "https://u.expo.dev/3256dcee-103a-467b-96c4-97a9f634df51",
+              "requestHeaders": {
+                "expo-channel-name": "production"
+              },
+              "fallbackToCacheTimeout": 0
+            },
+            "version": "v1.1.0-beta.7",
+            "jsEngine": "hermes",
+            "platforms": [
+              "ios",
+              "android"
+            ],
+            "sdkVersion": "53.0.0",
+            "experiments": {
+              "typedRoutes": true
+            },
+            "orientation": "portrait",
+            "newArchEnabled": true,
+            "runtimeVersion": {
+              "policy": "appVersion"
+            },
+            "androidStatusBar": {
+              "backgroundColor": "#0A3A2E"
+            },
+            "userInterfaceStyle": "automatic",
+            "assetBundlePatterns": [
+              "**/*"
+            ]
+          }
+        },
+        "assets": [
+          {
+            "bundleKey": "778ffc9fe8773a878e9c30a6304784de",
+            "fileSHA256": "i2Gkx-9w3JJ1PwSUl2SC9m_UFQ7CPfx3KrZeEDc6-lU",
+            "storageKey": "idnX8z03q4vGLzhYMPaQGBADjhqvWe67_afPqJ1vGzM",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "c79c3606a1cf168006ad3979763c7e0c",
+            "fileSHA256": "kGZm3WiTRq2iMs42ia3vkHtCV_obWT8DY40rlJf2SIQ",
+            "storageKey": "k-3xHp3vP8mR36WdccUZVPTRJKpP-zlyboWdkXCIQpQ",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "02bc1fa7c0313217bde2d65ccbff40c9",
+            "fileSHA256": "_6fuRbdkBbpzkhSVAI99aMneY5X0tpQdsGNGX244IyA",
+            "storageKey": "lfqeUjiWFXwowhxVDBEzxsbTOEzYxMLebljy5Bh1mpU",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "35ba0eaec5a4f5ed12ca16fabeae451d",
+            "fileSHA256": "hM9es7ICUPaeDkczvrTaX0F_BoKJKlrRteYlcHU8IbE",
+            "storageKey": "fMoMrsUeB5xWw_Ugn8FqGJf-M2pld2hkXKR704z0MM8",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "0a328cd9c1afd0afe8e3b1ec5165b1b4",
+            "fileSHA256": "mtuMXvypMuK3MrKT2oE70uMZUiYwVrzp4lF_7A8LanY",
+            "storageKey": "LM4SxB4vhDe2iN4tYT0dAlPP_dsY-Zme_H-JpULtHa8",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "3cd68ccdb8938e3711da2e8831b85493",
+            "fileSHA256": "yGu0he7mh-BsUA_EI09RpnhLRTDCrhHQx2SBEQvOMQU",
+            "storageKey": "A08F4i_QzJW79C3BCIZYmmpH_p2FkQbdTQZ_2hVWDeg",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "61ca7e64b7d605716c57706cef640b9a",
+            "fileSHA256": "0Dpc16Zu8QxRR5FvnVh4stCgpa1G9AWjHNmWfvqlWv0",
+            "storageKey": "04lOdmTXc1loPyqacYwao1j0xlM34n0vGxtIFY7ETTs",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "aff2c65b39a296d4f7e96d0f58169170",
+            "fileSHA256": "q1YT0s5w-mfFkm6DE1NmSUUZn8GV-m_nbF_jzsRS4xo",
+            "storageKey": "4s0taS6e9_zozzhgsa6FogUB4b0LQc1LMNbBLkxlIz0",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "d8e7601e3df962f83c62371ac14964d8",
+            "fileSHA256": "xOVOagp95jaqFTN4-8YupKQWlb_t-Af5Dfexj_1zP2c",
+            "storageKey": "g6PisuFJa8j79kTi3ZKboB3DcerIBZXujlFBVhXkh1s",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "3cd68ccdb8938e3711da2e8831b85493",
+            "fileSHA256": "yGu0he7mh-BsUA_EI09RpnhLRTDCrhHQx2SBEQvOMQU",
+            "storageKey": "A08F4i_QzJW79C3BCIZYmmpH_p2FkQbdTQZ_2hVWDeg",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "0747a1317bbe9c6fc340b889ef8ab3ae",
+            "fileSHA256": "IyXFOnPlTEOMu8YN_92LUT1HG6QuL1ZxPvQEuV4Mofw",
+            "storageKey": "DP7IegcRXP-7kIHiKmplB43A2HIM9nT01_O4JsXZKXI",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "d84e297c3b3e49a614248143d53e40ca",
+            "fileSHA256": "sbwYEMoj4sOM12lxxDWR1yYWEGEkDYt5KwV1cZbdtSg",
+            "storageKey": "aY8TciqT0pLONlgDC1iSLgQd6TyRf7NkBhUrJkfuqD0",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "1190ab078c57159f4245a328118fcd9a",
+            "fileSHA256": "y9-SE-VfZcSNB2rNhCO3ya7k8bgRAf9slaOMTNioZGE",
+            "storageKey": "mJsf9KoBQiKLAHO11XdSt59xshQZeDJmGEa9jlA_GY4",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "78c625386b4d0690b421eb0fc78f7b9c",
+            "fileSHA256": "0FydMNefRaeOVYWi5-xnxqBqiD3ZE34dUFnoyHszznY",
+            "storageKey": "yag9GLD2iZjnBBRuIa9kgMTdG2sabQ7v5K3JoDYQcqY",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "0747a1317bbe9c6fc340b889ef8ab3ae",
+            "fileSHA256": "IyXFOnPlTEOMu8YN_92LUT1HG6QuL1ZxPvQEuV4Mofw",
+            "storageKey": "DP7IegcRXP-7kIHiKmplB43A2HIM9nT01_O4JsXZKXI",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "4403c6117ec30c859bc95d70ce4a71d3",
+            "fileSHA256": "unIvskv_CkxS5lbN8gXerFxd-F5briv20wcTvVDG1fc",
+            "storageKey": "uG5CihBixNlPMeYN0V5MRwARA2Ovn0seNtMvhelV3kE",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "069d99eb1fa6712c0b9034a58c6b57dd",
+            "fileSHA256": "UwD1C-NlnRfYzuho7E5sDT9OiZRP1YmdPCD2p2egRfU",
+            "storageKey": "dV5iuhAavksqtDhoNxjh3ZJ3mjhWaRm_k_QMsxTkJRg",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "c3273c9e5321f20d1e42c2efae2578c4",
+            "fileSHA256": "bI8Rv9HH4idp3BNcFuzQ4FO7VVVNqIuWEdnPcdEhNvE",
+            "storageKey": "r81JaSP6EG6dxkyPe8l7CAVizX4cmddQVze71LebmUo",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "286d67d3f74808a60a78d3ebf1a5fb57",
+            "fileSHA256": "XQdeDCh8T0RBtbXI_H6lzSfBG7YX7OoJdVlVvLGIkIM",
+            "storageKey": "m9yS4VLFfdQtO3uDS8O8dWqyH7JfIBfBd3VkPnFGw6c",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "d1ea1496f9057eb392d5bbf3732a61b7",
+            "fileSHA256": "wV7HKnTROVchGAgxPVw13rf3YGxtItvdzrAADU4FR60",
+            "storageKey": "iiX0QENtWnFHr-ql_G75Cv2aoG8T9jbnoTrrLiduBMs",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "19eeb73b9593a38f8e9f418337fc7d10",
+            "fileSHA256": "ppou21tsYLhDPVttI8afUgzNimAvP2DnmW5Ilxi8F1w",
+            "storageKey": "0OEDV0a6nXu3m-NCyMZCejvRaLMgUJoN5kZZr6WGO9o",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "ab19f4cbc543357183a20571f68380a3",
+            "fileSHA256": "J_TSKdRAklv3IS1d__pF1Zayx7O7KQXJa4ObIIGh2-s",
+            "storageKey": "1QHSPNPuPJBWsSu-NeGsZJ65lgP9Nn9hUrFpSvorJ3Y",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "d8b800c443b8972542883e0b9de2bdc6",
+            "fileSHA256": "cIp5z1YbiipIUM4CVFhNOlIxBGvgj7f630tu39sxF4s",
+            "storageKey": "F0VhhOdSAZAGWHzCBT8frAxWVDzVgNYGLlSTnInMLk0",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "412dd9275b6b48ad28f5e3d81bb1f626",
+            "fileSHA256": "rPaRlXo7zOfRlYVtzpilzxTc4QvqKKpcELNVDAeOI7U",
+            "storageKey": "YbOaNgsSGzVwiIMg8au7XcXF5nhp0mKG64zufThcPZQ",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "20e71bdf79e3a97bf55fd9e164041578",
+            "fileSHA256": "78edo8TJffsVcb_2IClYqwUpxaox6DkmAFeLPjWdFEc",
+            "storageKey": "Ij5rVfQl_Hbg8xU1LXrdNRR__q6WTEE-FIneYIROiLQ",
+            "contentType": "image/png",
+            "fileExtension": ".png"
+          },
+          {
+            "bundleKey": "49a79d66bdea2debf1832bf4d7aca127",
+            "fileSHA256": "TDIlFNJlBiqj9_vYH1t5ORzLdCaOaiBgAGHgzjMjT0E",
+            "storageKey": "dmOaC6Uf95Cn4adL7UKjKsEcVkQ_ma4sXIuHYa9gadQ",
+            "contentType": "font/ttf",
+            "fileExtension": ".ttf"
+          }
+        ],
+        "launchAsset": {
+          "bundleKey": "e3592a3fad99b6e34b65d3fcda308b17",
+          "fileSHA256": "kCde3uvAPH20QNOTAebzHz3Ww7DLpZxpdu63VTG4IWU",
+          "storageKey": "UR6tvaqNuFhJFErO3gaUqc689wjnSNvmIJfVH0tX6F4",
+          "contentType": "application/javascript",
+          "fileExtension": ".hbc"
+        }
+      }
+    }
+  ]
+}

--- a/src/components/VersionDisplay.tsx
+++ b/src/components/VersionDisplay.tsx
@@ -7,47 +7,8 @@ interface VersionDisplayProps {
 }
 
 export const VersionDisplay: React.FC<VersionDisplayProps> = ({ style }) => {
-  const getVersion = (): string => {
-    // For local dev, show dev version with git info if available
-    const isDev = __DEV__ || Constants.appOwnership === "expo";
-    if (isDev) {
-      try {
-        // Try to import dev version file
-        const devVersion = require("../dev-version.json");
-        if (devVersion?.version && devVersion?.gitCommit) {
-          return `${devVersion.version}+${devVersion.gitCommit.substring(0, 7)}`;
-        }
-      } catch {
-        // Dev version file doesn't exist or can't be read
-      }
-      return "v1.0.0-dev";
-    }
-
-    // Use version with git hash injected by build pipeline, fallback to clean version
-    const version =
-      Constants.expoConfig?.extra?.version || Constants.expoConfig?.version;
-    if (version) {
-      return version;
-    }
-
-    // No version available
-    return "";
-  };
-
-  const version = getVersion();
-
-  // Don't render anything if no meaningful version is available
-  if (!version) {
-    return null;
-  }
-
-  return (
-    <View style={[styles.container, style]}>
-      <Text style={styles.versionText}>
-        {version.startsWith("v") ? version : `v${version}`}
-      </Text>
-    </View>
-  );
+  // Temporarily disable to test if this is causing splash screen issue
+  return null;
 };
 
 const styles = StyleSheet.create({

--- a/src/components/VersionDisplay.tsx
+++ b/src/components/VersionDisplay.tsx
@@ -7,8 +7,45 @@ interface VersionDisplayProps {
 }
 
 export const VersionDisplay: React.FC<VersionDisplayProps> = ({ style }) => {
-  // Temporarily disable to test if this is causing splash screen issue
-  return null;
+  const getVersion = (): string => {
+    // Only use dev version in actual development mode
+    if (__DEV__) {
+      try {
+        // Try to import dev version file
+        const devVersion = require("../dev-version.json");
+        if (devVersion?.version && devVersion?.gitCommit) {
+          return `${devVersion.version}+${devVersion.gitCommit.substring(0, 7)}`;
+        }
+      } catch {
+        // Dev version file doesn't exist or can't be read
+      }
+      return "v1.0.0-dev";
+    }
+
+    // For published builds, use version injected by build pipeline
+    try {
+      const version =
+        Constants.expoConfig?.extra?.version || Constants.expoConfig?.version;
+      if (version) {
+        return version;
+      }
+    } catch {
+      // Fallback if Constants access fails
+    }
+
+    // Final fallback for production builds
+    return "v1.0.0";
+  };
+
+  const version = getVersion();
+
+  return (
+    <View style={[styles.container, style]}>
+      <Text style={styles.versionText}>
+        {version.startsWith("v") ? version : `v${version}`}
+      </Text>
+    </View>
+  );
 };
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
## Summary
- Fixes splash screen hang that was preventing beta-6+ and alpha updates from loading in Expo Go
- Improves VersionDisplay environment detection to properly distinguish between development and production builds
- Removes unnecessary null check since component now always returns a version string

## Root Cause
The VersionDisplay component was using `Constants.appOwnership === "expo"` to detect development mode, but this was unreliable in EAS updates, causing published builds to try executing development logic and access non-existent files.

## Solution
- **Simplified dev detection**: Only use `__DEV__` flag for development mode detection
- **Robust fallbacks**: Added try/catch around Constants access and guaranteed fallback to "v1.0.0"
- **Cleaner logic**: Removed unreliable `Constants.appOwnership` check
- **Always renders**: Component always returns a version string, eliminating need for null checks

## Testing
- ✅ Alpha build loads successfully (confirmed splash screen issue resolved)
- ✅ All 532 tests pass
- ✅ No lint errors or TypeScript issues
- ✅ Local development still works correctly

## Impact
This resolves the critical issue preventing beta and alpha updates from loading in Expo Go since the versioning system implementation.

🤖 Generated with [Claude Code](https://claude.ai/code)