### PR TITLE
feat: add version output without git hash for clean APK filenames

### DIFF
--- a/.github/actions/git-version/action.yml
+++ b/.github/actions/git-version/action.yml
@@ -8,6 +8,9 @@ outputs:
   app-version:
     description: 'The app version for OTA compatibility (e.g., v1.0.0)'
     value: ${{ steps.detect.outputs.app-version }}
+  version:
+    description: 'The version without git hash (e.g., v1.0.3)'
+    value: ${{ steps.detect.outputs.version }}
   eas-branch:
     description: 'EAS Update branch'
     value: ${{ steps.detect.outputs.eas-branch }}
@@ -47,6 +50,7 @@ runs:
           else
             APP_VERSION="$RAW_VERSION"
           fi
+          VERSION="$RAW_VERSION"
           FULL_VERSION="${RAW_VERSION}+${GIT_HASH_SHORT}"
           EAS_BRANCH="production"
           
@@ -60,17 +64,20 @@ runs:
           else
             APP_VERSION="$RAW_VERSION"
           fi
+          VERSION="$RAW_VERSION"
           FULL_VERSION="${RAW_VERSION}+${GIT_HASH_SHORT}"
           EAS_BRANCH="production"
           
         elif [[ ${{ github.ref }} == refs/heads/main ]]; then
           # Main branch push
+          VERSION="v${BASE_VERSION}-beta.${COMMIT_COUNT}"
           APP_VERSION="v${BASE_VERSION}-beta.${COMMIT_COUNT}+${GIT_HASH_SHORT}"
           FULL_VERSION="v${BASE_VERSION}-beta.${COMMIT_COUNT}+${GIT_HASH_SHORT}"
           EAS_BRANCH="beta"
           
         else
           # Other branch (manual trigger)
+          VERSION="v${BASE_VERSION}-alpha.${COMMIT_COUNT}"
           APP_VERSION="v${BASE_VERSION}-alpha.${COMMIT_COUNT}+${GIT_HASH_SHORT}"
           FULL_VERSION="v${BASE_VERSION}-alpha.${COMMIT_COUNT}+${GIT_HASH_SHORT}"
           EAS_BRANCH="alpha"
@@ -79,12 +86,14 @@ runs:
         # Set all outputs
         echo "full-version=$FULL_VERSION" >> $GITHUB_OUTPUT
         echo "app-version=$APP_VERSION" >> $GITHUB_OUTPUT
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "eas-branch=$EAS_BRANCH" >> $GITHUB_OUTPUT
         
         # Verbose output for debugging
         echo "Final outputs:"
         echo "  full-version: $FULL_VERSION"
         echo "  app-version: $APP_VERSION"
+        echo "  version: $VERSION"
         echo "  eas-branch: $EAS_BRANCH"
 
     - name: Inject version into app.json

--- a/.github/workflows/eas-build-apk.yml
+++ b/.github/workflows/eas-build-apk.yml
@@ -54,12 +54,12 @@ jobs:
 
     - name: Download APK
       run: |
-        curl -L -o tractor-${{ steps.version.outputs.app-version }}.apk "${{ steps.build-url.outputs.build_url }}"
+        curl -L -o tractor-${{ steps.version.outputs.version }}.apk "${{ steps.build-url.outputs.build_url }}"
 
     - name: Upload APK to Release
       uses: softprops/action-gh-release@v2
       with:
-        files: tractor-${{ steps.version.outputs.app-version }}.apk
+        files: tractor-${{ steps.version.outputs.version }}.apk
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Add new `version` output to git-version action that provides version without git hash
- Update eas-build-apk workflow to use clean version for APK filenames
- Improves APK filename readability for releases

## Changes
- **git-version action**: New `version` output alongside existing `full-version` and `app-version`
- **eas-build-apk workflow**: Use `version` instead of `app-version` for APK filenames

## APK Filename Examples
- **Production**: `tractor-v1.0.3.apk` (actual release version instead of normalized)
- **Beta**: `tractor-v1.1.0-beta.5.apk` (without git hash clutter)
- **Alpha**: `tractor-v1.1.0-alpha.3.apk` (without git hash clutter)

## Test plan
- [x] Verify git-version action outputs include new `version` field
- [x] Confirm APK workflow references correct version output
- [ ] Test with actual release to verify clean APK filename

🤖 Generated with [Claude Code](https://claude.ai/code)