### PR TITLE
feat: exclude patch tags from base version calculation

### DIFF
--- a/.github/actions/git-version/action.yml
+++ b/.github/actions/git-version/action.yml
@@ -26,8 +26,8 @@ runs:
         GIT_COMMIT=$(git rev-parse HEAD)
         GIT_HASH_SHORT=$(git rev-parse --short HEAD)
         
-        # Get base version and commit count (only look for version tags)
-        LAST_TAG=$(git tag -l "v*.*.*" --sort=-version:refname | head -n1 || echo "")
+        # Get base version and commit count (only look for minor/major version tags, exclude patches)
+        LAST_TAG=$(git tag -l "v*.*.0" --sort=-version:refname | head -n1 || echo "")
         if [[ -n "$LAST_TAG" ]]; then
           LAST_VERSION=${LAST_TAG#v}
           # Increment minor version by 1 and reset patch to 0

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ A React Native implementation of the classic Chinese card game **Tractor** (also
 ![TypeScript](https://img.shields.io/badge/TypeScript-Strict-green)
 ![Tests](https://img.shields.io/badge/Tests-532%20Passing-brightgreen?logo=jest)
 ![EAS Update](https://github.com/ejfn/Tractor/actions/workflows/eas-update.yml/badge.svg?branch=main)
-![EAS Build APK](https://github.com/ejfn/Tractor/actions/workflows/eas-build-apk.yml/badge.svg?branch=main)
 
 ## What is Tractor?
 

--- a/scripts/inject-dev-version.js
+++ b/scripts/inject-dev-version.js
@@ -13,7 +13,7 @@ try {
   // Get latest version tag and calculate next minor version
   let baseVersion = "1.0.0";
   try {
-    const lastTag = execSync('git tag -l "v*.*.*" --sort=-version:refname', { encoding: 'utf8' }).trim().split('\n')[0];
+    const lastTag = execSync('git tag -l "v*.*.0" --sort=-version:refname', { encoding: 'utf8' }).trim().split('\n')[0];
     if (lastTag) {
       const lastVersion = lastTag.replace('v', '');
       const [major, minor, patch] = lastVersion.split('.').map(Number);


### PR DESCRIPTION
## Summary
- Update version calculation logic to only consider minor/major release tags (v*.*.0)
- Exclude patch releases from base version calculation
- Remove EAS Build APK badge from README (not suitable for CI status)

## Problem Solved
Previously, beta builds would reset their count after every patch release:
- Last tag: `v1.0.3` → next beta: `v1.1.0-beta.1`
- Create patch: `v1.0.4` → next beta: `v1.1.0-beta.1` (count resets\! 😞)

## Solution
Now beta builds maintain incremental count across patch releases:
- Last minor: `v1.0.0` → next beta: `v1.1.0-beta.1`
- Create patches: `v1.0.1`, `v1.0.2`, `v1.0.3` → still `v1.1.0-beta.X` (count continues\! ✅)
- Only when creating `v1.1.0` will next beta become `v1.2.0-beta.1`

## Changes Made

### Git Version Action
```bash
# Before
LAST_TAG=$(git tag -l "v*.*.*" --sort=-version:refname  < /dev/null |  head -n1)

# After  
LAST_TAG=$(git tag -l "v*.*.0" --sort=-version:refname | head -n1)
```

### Dev Version Script
```javascript
// Before
const lastTag = execSync('git tag -l "v*.*.*" --sort=-version:refname'...

// After
const lastTag = execSync('git tag -l "v*.*.0" --sort=-version:refname'...
```

### README
- Remove EAS Build APK badge (only runs on releases, not suitable for CI status)

## Benefits
- **Consistent beta versioning**: Beta count increments logically across development
- **Predictable dev versions**: Development versions stay consistent until minor releases
- **Better workflow**: Patch releases don't disrupt ongoing beta development
- **Unified logic**: Same tag filtering across all version calculation systems

## Test plan
- [x] Verify git-version action uses minor/major tags only
- [x] Confirm dev version script matches same logic
- [x] README badge cleanup
- [ ] Test beta count persistence across patch releases in practice

🤖 Generated with [Claude Code](https://claude.ai/code)