### PR TITLE
Fix new game state reset

### DIFF
--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -323,8 +323,11 @@ export function useGameState() {
     setShowSetupInternal(false);
     setGameOver(false);
     setWinner(null);
+    setShowRoundComplete(false);
+    setRoundCompleteMessage("");
     setPreviousGamePhase(null);
     pendingStateRef.current = null;
+    roundResultRef.current = null;
     kittyCardsRef.current = [];
 
     // Initialize will be called on next render due to dependency changes


### PR DESCRIPTION
## Summary
- reset round complete state when starting a new game

## Testing
- `npm test` *(fails: jest not found)*
- `npm run typecheck` *(fails: ts errors, expo config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68442ca3598c832c884e455eb88b0f63