### PR TITLE
test: add comprehensive regression test for Issue #172 cross-suit following bug

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ npm run qualitycheck  # Runs all checks
 - **NO LINT WARNINGS/ERRORS**: All ESLint warnings and errors must be resolved.
 - **TYPECHECK MUST PASS**: No TypeScript compilation errors allowed.
 - **Zero Tolerance Policy**: `npm run qualitycheck` must pass completely with no failures or warnings before any commit.
-- **Current Test Count**: 618 tests passing (update README.md badge when count changes)
+- **Current Test Count**: 622 tests passing (update README.md badge when count changes)
 
 ### Git Workflow
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A React Native implementation of the classic Chinese card game **Tractor** (also
 ![Platforms](https://img.shields.io/badge/Platforms-Android%20%7C%20iOS-blue)
 ![React Native](https://img.shields.io/badge/React%20Native-Expo-blue)
 ![TypeScript](https://img.shields.io/badge/TypeScript-Strict-green)
-![Tests](https://img.shields.io/badge/Tests-618%20Passing-brightgreen?logo=jest)
+![Tests](https://img.shields.io/badge/Tests-622%20Passing-brightgreen?logo=jest)
 ![EAS Update](https://github.com/ejfn/Tractor/actions/workflows/eas-update.yml/badge.svg?branch=main)
 
 ## What is Tractor?

--- a/__tests__/ai/issue172CrossSuitFollowingBug.test.ts
+++ b/__tests__/ai/issue172CrossSuitFollowingBug.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Regression test for Issue #172: AI violates following rules by playing cross-suit cards
+ * when same-suit cards are available
+ * 
+ * This test validates that AI players properly follow Tractor/Shengji rules when following pairs:
+ * 1. Must follow suit and match combination type if possible
+ * 2. Must exhaust all cards from leading suit before using other suits
+ * 3. Cannot play cross-suit combinations when same-suit cards are available
+ */
+
+import { getAIMove } from '../../src/ai/aiLogic';
+import { createBasicGameState } from '../helpers';
+import { PlayerId, GamePhase, Suit, Rank, Card, JokerType } from '../../src/types';
+
+// Helper function to create cards
+const createCardWithPoints = (suit: Suit, rank: Rank, id: string): Card => {
+  let points = 0;
+  if (rank === Rank.Five) points = 5;
+  if (rank === Rank.Ten || rank === Rank.King) points = 10;
+  return { suit, rank, id, points };
+};
+
+const createJoker = (type: JokerType, id: string): Card => {
+  return { joker: type, id, points: 0 };
+};
+
+describe('Issue #172: AI Cross-Suit Following Bug', () => {
+  
+  test('AI should not play cross-suit cards when same-suit pair following is possible', () => {
+    const gameState = createBasicGameState();
+    
+    // Create trick with human leading 7♥-7♥ pair
+    gameState.currentTrick = {
+      plays: [
+        {
+          playerId: PlayerId.Human,
+          cards: [
+            createCardWithPoints(Suit.Hearts, Rank.Seven, 'hearts_7_1'),
+            createCardWithPoints(Suit.Hearts, Rank.Seven, 'hearts_7_2')
+          ]
+        }
+      ],
+      winningPlayerId: PlayerId.Human,
+      points: 0
+    };
+
+    // Give AI Bot1 multiple hearts including pairs
+    gameState.players[1].hand = [
+      createCardWithPoints(Suit.Hearts, Rank.Five, 'hearts_5_1'),   // Hearts available
+      createCardWithPoints(Suit.Hearts, Rank.Five, 'hearts_5_2'),   // Hearts pair available
+      createCardWithPoints(Suit.Hearts, Rank.Nine, 'hearts_9_1'),   // More hearts
+      createCardWithPoints(Suit.Hearts, Rank.Queen, 'hearts_q_1'),  // More hearts
+      createCardWithPoints(Suit.Spades, Rank.Eight, 'spades_8_1'),  // Other suit
+      createCardWithPoints(Suit.Spades, Rank.Eight, 'spades_8_2'),  // Other suit pair
+      createCardWithPoints(Suit.Clubs, Rank.King, 'clubs_k_1'),     // Other suit
+      createCardWithPoints(Suit.Diamonds, Rank.Ace, 'diamonds_a_1') // Other suit
+    ];
+
+    gameState.currentPlayerIndex = 1; // Bot1's turn to follow
+
+    // AI should follow the pair lead
+    const aiResponse = getAIMove(gameState, PlayerId.Bot1);
+
+    // Validate AI response
+    expect(aiResponse).toHaveLength(2); // Should play exactly 2 cards (pair)
+    
+    // Critical validation: Both cards must be from the same suit (Hearts)
+    expect(aiResponse[0].suit).toBe(Suit.Hearts);
+    expect(aiResponse[1].suit).toBe(Suit.Hearts);
+    
+    // Additional validation: Should be a proper pair or at least both hearts
+    const suits = aiResponse.map(card => card.suit);
+    const uniqueSuits = new Set(suits);
+    expect(uniqueSuits.size).toBe(1); // All cards from same suit
+    expect(uniqueSuits.has(Suit.Hearts)).toBe(true); // Must be hearts
+  });
+
+  test('AI should exhaust all hearts before using other suits when following pairs', () => {
+    const gameState = createBasicGameState();
+    
+    // Create trick with human leading K♥-K♥ pair
+    gameState.currentTrick = {
+      plays: [
+        {
+          playerId: PlayerId.Human,
+          cards: [
+            createCardWithPoints(Suit.Hearts, Rank.King, 'hearts_k_1'),
+            createCardWithPoints(Suit.Hearts, Rank.King, 'hearts_k_2')
+          ]
+        }
+      ],
+      winningPlayerId: PlayerId.Human,
+      points: 20 // Two Kings = 20 points
+    };
+
+    // AI bot with insufficient hearts for pair but has some hearts
+    gameState.players[1].hand = [
+      createCardWithPoints(Suit.Hearts, Rank.Three, 'hearts_3_1'),   // Only one heart rank available
+      createCardWithPoints(Suit.Hearts, Rank.Seven, 'hearts_7_1'),   // Different heart rank
+      createCardWithPoints(Suit.Spades, Rank.Ten, 'spades_10_1'),    // Other suit pair
+      createCardWithPoints(Suit.Spades, Rank.Ten, 'spades_10_2'),    // Other suit pair
+      createCardWithPoints(Suit.Clubs, Rank.Queen, 'clubs_q_1'),     // Other suit
+      createCardWithPoints(Suit.Diamonds, Rank.Ace, 'diamonds_a_1')  // Other suit
+    ];
+
+    gameState.currentPlayerIndex = 1; // Bot1's turn to follow
+
+    const aiResponse = getAIMove(gameState, PlayerId.Bot1);
+
+    expect(aiResponse).toHaveLength(2); // Must play 2 cards to follow pair
+    
+    // Should use all available hearts (2 cards) instead of cross-suit
+    const heartsPlayed = aiResponse.filter(card => card.suit === Suit.Hearts);
+    expect(heartsPlayed).toHaveLength(2); // Should use both available hearts
+    
+    // Validate no cross-suit mixing
+    const suits = aiResponse.map(card => card.suit);
+    const uniqueSuits = new Set(suits);
+    expect(uniqueSuits.size).toBe(1); // All cards from same suit
+  });
+
+  test('AI should only use cross-suit when completely out of leading suit', () => {
+    const gameState = createBasicGameState();
+    
+    // Create trick with human leading A♥-A♥ pair
+    gameState.currentTrick = {
+      plays: [
+        {
+          playerId: PlayerId.Human,
+          cards: [
+            createCardWithPoints(Suit.Hearts, Rank.Ace, 'hearts_a_1'),
+            createCardWithPoints(Suit.Hearts, Rank.Ace, 'hearts_a_2')
+          ]
+        }
+      ],
+      winningPlayerId: PlayerId.Human,
+      points: 0
+    };
+
+    // AI bot with NO hearts - can use other suits
+    gameState.players[1].hand = [
+      createCardWithPoints(Suit.Spades, Rank.Ten, 'spades_10_1'),    // Other suit pair
+      createCardWithPoints(Suit.Spades, Rank.Ten, 'spades_10_2'),    // Other suit pair
+      createCardWithPoints(Suit.Clubs, Rank.Queen, 'clubs_q_1'),     // Other suit
+      createCardWithPoints(Suit.Diamonds, Rank.King, 'diamonds_k_1'), // Other suit
+      createCardWithPoints(Suit.Spades, Rank.Five, 'spades_5_1'),    // Other suit
+      createCardWithPoints(Suit.Clubs, Rank.Jack, 'clubs_j_1')       // Other suit
+    ];
+
+    gameState.currentPlayerIndex = 1; // Bot1's turn to follow
+
+    const aiResponse = getAIMove(gameState, PlayerId.Bot1);
+
+    expect(aiResponse).toHaveLength(2); // Must play 2 cards
+    
+    // Verify no hearts were played (since AI has none)
+    const heartsPlayed = aiResponse.filter(card => card.suit === Suit.Hearts);
+    expect(heartsPlayed).toHaveLength(0);
+    
+    // This scenario is valid - AI can play from other suits when out of hearts
+    // The key is that AI should prioritize pairs from same suit when possible
+    const suits = aiResponse.map(card => card.suit);
+    
+    // If AI plays a pair, it should be from same suit
+    if (aiResponse[0].rank === aiResponse[1].rank) {
+      const uniqueSuits = new Set(suits);
+      expect(uniqueSuits.size).toBe(1); // Pair should be from same suit
+    }
+  });
+
+  test('AI should prefer same-suit pairs over cross-suit combinations', () => {
+    const gameState = createBasicGameState();
+    
+    // Create trick with human leading 9♦-9♦ pair
+    gameState.currentTrick = {
+      plays: [
+        {
+          playerId: PlayerId.Human,
+          cards: [
+            createCardWithPoints(Suit.Diamonds, Rank.Nine, 'diamonds_9_1'),
+            createCardWithPoints(Suit.Diamonds, Rank.Nine, 'diamonds_9_2')
+          ]
+        }
+      ],
+      winningPlayerId: PlayerId.Human,
+      points: 0
+    };
+
+    // AI with multiple options including same-suit pair
+    gameState.players[1].hand = [
+      createCardWithPoints(Suit.Diamonds, Rank.Jack, 'diamonds_j_1'),  // Diamond available
+      createCardWithPoints(Suit.Diamonds, Rank.Jack, 'diamonds_j_2'),  // Diamond pair available
+      createCardWithPoints(Suit.Diamonds, Rank.Queen, 'diamonds_q_1'), // More diamonds
+      createCardWithPoints(Suit.Hearts, Rank.Eight, 'hearts_8_1'),     // Other suit pair
+      createCardWithPoints(Suit.Hearts, Rank.Eight, 'hearts_8_2'),     // Other suit pair
+      createCardWithPoints(Suit.Spades, Rank.King, 'spades_k_1'),      // Other suit
+      createCardWithPoints(Suit.Clubs, Rank.Ace, 'clubs_a_1')         // Other suit
+    ];
+
+    gameState.currentPlayerIndex = 1; // Bot1's turn to follow
+
+    const aiResponse = getAIMove(gameState, PlayerId.Bot1);
+
+    expect(aiResponse).toHaveLength(2);
+    
+    // AI should prioritize diamond pair over cross-suit play
+    expect(aiResponse[0].suit).toBe(Suit.Diamonds);
+    expect(aiResponse[1].suit).toBe(Suit.Diamonds);
+    
+    // Should be the J♦-J♦ pair specifically
+    expect(aiResponse[0].rank).toBe(Rank.Jack);
+    expect(aiResponse[1].rank).toBe(Rank.Jack);
+  });
+});


### PR DESCRIPTION
## Summary
- Add comprehensive regression test validating AI suit-following rules for pairs
- Update test count badges from 618 to 622 tests  
- Confirm Issue #172 cross-suit following bug has been resolved

## Bug Resolution

Issue #172 reported that AI players were violating fundamental Tractor/Shengji rules by playing cards from different suits when same-suit cards were available. This regression test confirms the bug has been **automatically resolved** by the AI architecture refactoring (#173).

## Test Coverage

Added `__tests__/ai/issue172CrossSuitFollowingBug.test.ts` with 4 comprehensive scenarios:

1. **✅ Same-suit pair following** - AI correctly follows pairs when same-suit available
2. **✅ Suit exhaustion** - AI uses all leading suit cards before other suits  
3. **✅ Valid cross-suit** - AI only uses cross-suit when completely out of leading suit
4. **✅ Pair preference** - AI prefers same-suit pairs over cross-suit combinations

## Verification

**All 4 tests PASS**, confirming that the modular AI system with specialized following strategies (`src/ai/following/`) now correctly implements game rules and no longer violates suit-following constraints.

## Documentation Updates

- Updated README.md test badge: 618 → 622 tests
- Updated CLAUDE.md test count: 618 → 622 tests

## Test Plan
- [x] All 622 tests pass (4 new regression tests added)
- [x] Quality checks pass (lint, typecheck)
- [x] Regression test validates bug resolution
- [x] Issue #172 closed as resolved

🤖 Generated with [Claude Code](https://claude.ai/code)