### PR TITLE
Fix: Invalid Cross-Suit Pair Bug - Enforce Identical Card Pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A React Native implementation of the classic Chinese card game **Tractor** (also
 ![Platforms](https://img.shields.io/badge/Platforms-Android%20%7C%20iOS-blue)
 ![React Native](https://img.shields.io/badge/React%20Native-Expo-blue)
 ![TypeScript](https://img.shields.io/badge/TypeScript-Strict-green)
-![Tests](https://img.shields.io/badge/Tests-648%20Passing-brightgreen?logo=jest)
+![Tests](https://img.shields.io/badge/Tests-654%20Passing-brightgreen?logo=jest)
 ![EAS Update](https://github.com/ejfn/Tractor/actions/workflows/eas-update.yml/badge.svg?branch=main)
 
 ## What is Tractor?

--- a/__tests__/ai/invalidCrossSuitPairBug.test.ts
+++ b/__tests__/ai/invalidCrossSuitPairBug.test.ts
@@ -1,0 +1,91 @@
+import { identifyCombos } from '../../src/game/gameLogic';
+import { ComboType, Rank, Suit, TrumpInfo } from '../../src/types';
+import { createCard } from '../helpers';
+
+describe('Invalid Cross-Suit Pair Bug Fix', () => {
+  test('should NOT create pair from different suit trump rank cards', () => {
+    const trumpInfo: TrumpInfo = {
+      trumpRank: Rank.Two,
+      trumpSuit: Suit.Spades,
+    };
+
+    // Create cards: 2♥ and 2♦ (both trump rank, different suits)
+    const cards = [
+      createCard(Suit.Hearts, Rank.Two), // 2♥ - trump rank card
+      createCard(Suit.Diamonds, Rank.Two), // 2♦ - trump rank card
+    ];
+
+    const combos = identifyCombos(cards, trumpInfo);
+
+    // Should find 2 singles but NO pairs
+    const pairs = combos.filter(combo => combo.type === ComboType.Pair);
+    const singles = combos.filter(combo => combo.type === ComboType.Single);
+
+    expect(singles).toHaveLength(2);
+    expect(pairs).toHaveLength(0); // Bug fix: No cross-suit pairs
+
+    // Verify both singles are trump rank cards
+    expect(singles[0].cards[0].rank).toBe(Rank.Two);
+    expect(singles[1].cards[0].rank).toBe(Rank.Two);
+    expect(singles[0].cards[0].suit).not.toBe(singles[1].cards[0].suit);
+  });
+
+  test('should create pair from identical trump rank cards (same suit)', () => {
+    const trumpInfo: TrumpInfo = {
+      trumpRank: Rank.Two,
+      trumpSuit: Suit.Spades,
+    };
+
+    // Create cards: two identical 2♥ cards
+    const cards = [
+      createCard(Suit.Hearts, Rank.Two), // 2♥ - trump rank card
+      createCard(Suit.Hearts, Rank.Two), // 2♥ - identical trump rank card
+    ];
+
+    const combos = identifyCombos(cards, trumpInfo);
+
+    // Should find 2 singles AND 1 pair from identical cards
+    const pairs = combos.filter(combo => combo.type === ComboType.Pair);
+    const singles = combos.filter(combo => combo.type === ComboType.Single);
+
+    expect(singles).toHaveLength(2);
+    expect(pairs).toHaveLength(1); // Should correctly find identical pair
+
+    // Verify pair contains identical cards
+    expect(pairs[0].cards).toHaveLength(2);
+    expect(pairs[0].cards[0].rank).toBe(Rank.Two);
+    expect(pairs[0].cards[0].suit).toBe(Suit.Hearts);
+    expect(pairs[0].cards[1].rank).toBe(Rank.Two);
+    expect(pairs[0].cards[1].suit).toBe(Suit.Hearts);
+  });
+
+  test('should handle mixed trump scenarios correctly', () => {
+    const trumpInfo: TrumpInfo = {
+      trumpRank: Rank.King,
+      trumpSuit: Suit.Clubs,
+    };
+
+    // Mix of trump rank cards and trump suit cards
+    const cards = [
+      createCard(Suit.Hearts, Rank.King), // K♥ - trump rank card
+      createCard(Suit.Diamonds, Rank.King), // K♦ - trump rank card (different suit)
+      createCard(Suit.Clubs, Rank.Ace), // A♣ - trump suit card
+      createCard(Suit.Clubs, Rank.Ace), // A♣ - identical trump suit card
+    ];
+
+    const combos = identifyCombos(cards, trumpInfo);
+
+    const pairs = combos.filter(combo => combo.type === ComboType.Pair);
+    const singles = combos.filter(combo => combo.type === ComboType.Single);
+
+    expect(singles).toHaveLength(4);
+    expect(pairs).toHaveLength(1); // Only the identical A♣-A♣ pair
+
+    // Verify the pair is the identical trump suit cards
+    const pair = pairs[0];
+    expect(pair.cards[0].rank).toBe(Rank.Ace);
+    expect(pair.cards[0].suit).toBe(Suit.Clubs);
+    expect(pair.cards[1].rank).toBe(Rank.Ace);
+    expect(pair.cards[1].suit).toBe(Suit.Clubs);
+  });
+});

--- a/__tests__/ai/invalidTrumpRankPairBug.test.ts
+++ b/__tests__/ai/invalidTrumpRankPairBug.test.ts
@@ -1,0 +1,113 @@
+import { identifyCombos } from '../../src/game/gameLogic';
+import { ComboType, JokerType, PlayerId, Rank, Suit, TrumpInfo } from '../../src/types';
+import { createCard } from '../helpers';
+
+describe('Invalid Trump Rank Pair Bug', () => {
+  test('should NOT create pair from different suit trump rank cards', () => {
+    // Setup: Trump rank 2, trump suit Spades
+    const trumpInfo: TrumpInfo = {
+      trumpRank: Rank.Two,
+      trumpSuit: Suit.Spades,
+    };
+
+    // Create cards: 2♥ and 2♦ (both trump rank, different suits)
+    const cards = [
+      createCard(Suit.Hearts, Rank.Two), // 2♥ - trump rank card
+      createCard(Suit.Diamonds, Rank.Two), // 2♦ - trump rank card
+    ];
+
+    const combos = identifyCombos(cards, trumpInfo);
+
+    // DEBUG: Let's see what combinations are actually found
+    console.log('DEBUG: All combos found:', combos);
+    console.log('DEBUG: Cards input:', cards);
+    
+    // Should find 2 singles but NO pairs
+    const pairs = combos.filter(combo => combo.type === ComboType.Pair);
+    const singles = combos.filter(combo => combo.type === ComboType.Single);
+
+    console.log('DEBUG: Pairs found:', pairs);
+    console.log('DEBUG: Singles found:', singles);
+
+    expect(singles).toHaveLength(2);
+    expect(pairs).toHaveLength(0); // Should NOT find pairs from different suits
+
+    // Verify singles are correct
+    expect(singles[0].cards[0]).toEqual(expect.objectContaining({
+      rank: Rank.Two,
+      suit: Suit.Hearts
+    }));
+    expect(singles[1].cards[0]).toEqual(expect.objectContaining({
+      rank: Rank.Two, 
+      suit: Suit.Diamonds
+    }));
+  });
+
+  test('should create pair from identical trump rank cards (same suit)', () => {
+    // Setup: Trump rank 2, trump suit Spades  
+    const trumpInfo: TrumpInfo = {
+      trumpRank: Rank.Two,
+      trumpSuit: Suit.Spades,
+    };
+
+    // Create cards: two 2♥ cards (identical)
+    const cards = [
+      createCard(Suit.Hearts, Rank.Two), // 2♥ - trump rank card
+      createCard(Suit.Hearts, Rank.Two), // 2♥ - identical trump rank card
+    ];
+
+    const combos = identifyCombos(cards, trumpInfo);
+
+    // Should find 2 singles AND 1 pair
+    const pairs = combos.filter(combo => combo.type === ComboType.Pair);
+    const singles = combos.filter(combo => combo.type === ComboType.Single);
+
+    expect(singles).toHaveLength(2);
+    expect(pairs).toHaveLength(1); // Should correctly find identical pair
+
+    // Verify pair contains identical cards
+    expect(pairs[0].cards).toHaveLength(2);
+    expect(pairs[0].cards[0]).toEqual(expect.objectContaining({
+      rank: Rank.Two,
+      suit: Suit.Hearts
+    }));
+    expect(pairs[0].cards[1]).toEqual(expect.objectContaining({
+      rank: Rank.Two,
+      suit: Suit.Hearts
+    }));
+  });
+
+  test('should create pair from trump suit cards (same rank and suit)', () => {
+    // Setup: Trump rank 2, trump suit Spades
+    const trumpInfo: TrumpInfo = {
+      trumpRank: Rank.Two,
+      trumpSuit: Suit.Spades,
+    };
+
+    // Create cards: two 3♠ cards (trump suit cards)
+    const cards = [
+      createCard(Suit.Spades, Rank.Three), // 3♠ - trump suit card
+      createCard(Suit.Spades, Rank.Three), // 3♠ - identical trump suit card
+    ];
+
+    const combos = identifyCombos(cards, trumpInfo);
+
+    // Should find 2 singles AND 1 pair
+    const pairs = combos.filter(combo => combo.type === ComboType.Pair);
+    const singles = combos.filter(combo => combo.type === ComboType.Single);
+
+    expect(singles).toHaveLength(2);
+    expect(pairs).toHaveLength(1); // Should correctly find identical pair
+
+    // Verify pair contains identical cards
+    expect(pairs[0].cards).toHaveLength(2);
+    expect(pairs[0].cards[0]).toEqual(expect.objectContaining({
+      rank: Rank.Three,
+      suit: Suit.Spades
+    }));
+    expect(pairs[0].cards[1]).toEqual(expect.objectContaining({
+      rank: Rank.Three,
+      suit: Suit.Spades
+    }));
+  });
+});

--- a/__tests__/game/trumpSystem.test.ts
+++ b/__tests__/game/trumpSystem.test.ts
@@ -95,16 +95,16 @@ describe('Trump System', () => {
       const cards = [fourSpades, fourDiamonds];
       const combos = identifyCombos(cards, trumpInfo);
       
-      // Should identify as two singles AND a cross-suit trump rank pair
-      // This is correct behavior according to Tractor rules - all trump cards are treated as same suit
-      expect(combos).toHaveLength(3); // 2 singles + 1 pair
+      // Should identify as two singles but NO pairs
+      // Trump cards are treated as same suit for FOLLOWING, but pairs require identical cards
+      expect(combos).toHaveLength(2); // 2 singles only
       expect(combos.filter(combo => combo.type === ComboType.Single)).toHaveLength(2);
-      expect(combos.filter(combo => combo.type === ComboType.Pair)).toHaveLength(1);
+      expect(combos.filter(combo => combo.type === ComboType.Pair)).toHaveLength(0);
       
-      // Verify the pair contains both trump rank cards
-      const pairCombo = combos.find(combo => combo.type === ComboType.Pair);
-      expect(pairCombo!.cards).toHaveLength(2);
-      expect(pairCombo!.cards.map(c => c.id).sort()).toEqual(['Spades_4', 'Diamonds_4'].sort());
+      // Verify both singles are trump rank cards
+      const singleCombos = combos.filter(combo => combo.type === ComboType.Single);
+      expect(singleCombos[0].cards[0].rank).toBe(Rank.Four);
+      expect(singleCombos[1].cards[0].rank).toBe(Rank.Four);
     });
 
     test('should not identify mixed joker pairs', () => {

--- a/src/game/gameLogic.ts
+++ b/src/game/gameLogic.ts
@@ -633,15 +633,32 @@ export const identifyCombos = (
     const cardsByRank = groupCardsByRank(suitCards);
 
     Object.values(cardsByRank).forEach((rankCards) => {
-      // Pairs
+      // Pairs: Only create pairs from IDENTICAL cards (same rank AND same suit)
+      // Trump unification applies to following, not pair formation
       if (rankCards.length >= 2) {
-        for (let i = 0; i < rankCards.length - 1; i++) {
-          combos.push({
-            type: ComboType.Pair,
-            cards: [rankCards[i], rankCards[i + 1]],
-            value: getCardValue(rankCards[i], trumpInfo),
-          });
-        }
+        // Group cards by suit within the same rank to ensure identical pairs
+        const cardsBySuitWithinRank: Record<string, Card[]> = {};
+
+        rankCards.forEach((card) => {
+          const suitKey = card.suit || "unknown";
+          if (!cardsBySuitWithinRank[suitKey]) {
+            cardsBySuitWithinRank[suitKey] = [];
+          }
+          cardsBySuitWithinRank[suitKey].push(card);
+        });
+
+        // Only create pairs from cards with identical suit AND rank
+        Object.values(cardsBySuitWithinRank).forEach((identicalCards) => {
+          if (identicalCards.length >= 2) {
+            for (let i = 0; i < identicalCards.length - 1; i++) {
+              combos.push({
+                type: ComboType.Pair,
+                cards: [identicalCards[i], identicalCards[i + 1]],
+                value: getCardValue(identicalCards[i], trumpInfo),
+              });
+            }
+          }
+        });
       }
     });
   });


### PR DESCRIPTION
## Summary
- **Fixed fundamental game rule violation**: AI was incorrectly treating different suit trump rank cards (e.g., 2♥-2♦) as valid pairs
- **Enhanced pair formation logic** to require identical cards (same rank AND same suit) regardless of trump status
- **Maintained trump unification** for following rules while enforcing correct pair formation requirements

## Root Cause Analysis
The trump unification fix for Issue #176 (which correctly treats all trump cards as same suit for following purposes) had an unintended side effect - it was allowing different suit trump rank cards to form pairs, violating the fundamental rule that pairs must be identical cards.

## Technical Implementation
- **Modified `identifyCombos()` in `src/game/gameLogic.ts:633-663`**
- **Added secondary suit grouping** within rank groups to ensure only identical cards can form pairs
- **Preserved trump unification** for following logic while enforcing pair formation rules
- **Comprehensive test coverage** with regression tests and edge case validation

## Test Coverage
- **Primary regression test**: `invalidCrossSuitPairBug.test.ts` - validates fix for reported issue
- **Updated existing tests**: `trumpSystem.test.ts` - corrected expectations to match proper game rules
- **All 654 tests passing** - maintains full test coverage with correct game rule compliance
- **Updated README.md** - test count badge reflects current passing test count

## Game Rule Compliance
✅ **Pairs Formation**: Only identical cards (same rank AND same suit) can form pairs
✅ **Trump Following**: All trump cards treated as same suit when following trump leads  
✅ **Trump Hierarchy**: Proper trump group unification maintained for trick-taking logic
✅ **Edge Cases**: Handles mixed trump scenarios, joker pairs, and complex combinations correctly

🤖 Generated with [Claude Code](https://claude.ai/code)