### PR TITLE
Fix: Enforce tractor following validation - all pairs before singles

### DIFF
--- a/__tests__/ai/aiNonTrumpTractorFollowing.test.ts
+++ b/__tests__/ai/aiNonTrumpTractorFollowing.test.ts
@@ -1,0 +1,194 @@
+import { getAIMove } from '../../src/ai/aiLogic';
+import { initializeGame } from '../../src/utils/gameInitialization';
+import { Card, Suit, Rank, PlayerId, GamePhase, TrumpInfo } from '../../src/types';
+
+describe('AI Non-Trump Tractor Following: Pair Priority', () => {
+  let gameState: any;
+  let trumpInfo: TrumpInfo;
+
+  beforeEach(() => {
+    gameState = initializeGame();
+    trumpInfo = {
+      trumpRank: Rank.Five,
+      trumpSuit: Suit.Hearts,
+    };
+    gameState.trumpInfo = trumpInfo;
+    gameState.gamePhase = GamePhase.Playing;
+  });
+
+  it('should use ALL available pairs before singles when following non-trump tractor', () => {
+    // Issue 207 scenario: AI should follow validation rules for non-trump tractor following
+    
+    // Bot2 leads Diamond tractor
+    const leadingTractor = [
+      Card.createCard(Suit.Diamonds, Rank.Three, 0),
+      Card.createCard(Suit.Diamonds, Rank.Three, 1),
+      Card.createCard(Suit.Diamonds, Rank.Four, 0),
+      Card.createCard(Suit.Diamonds, Rank.Four, 1)
+    ];
+
+    gameState.currentTrick = {
+      plays: [
+        { playerId: PlayerId.Bot2, cards: leadingTractor }
+      ],
+      winningPlayerId: PlayerId.Bot2,
+      points: 0
+    };
+
+    // Set Bot3 as current player
+    gameState.currentPlayerIndex = 3;
+    const bot3Player = gameState.players[3];
+
+    // Bot3 has multiple pairs available - should use ALL pairs before any singles
+    bot3Player.hand = [
+      // Available pairs (should use BOTH)
+      Card.createCard(Suit.Diamonds, Rank.Ace, 0),
+      Card.createCard(Suit.Diamonds, Rank.Ace, 1),
+      Card.createCard(Suit.Diamonds, Rank.Seven, 0),
+      Card.createCard(Suit.Diamonds, Rank.Seven, 1),
+      // Singles (should NOT use these when pairs available)
+      Card.createCard(Suit.Diamonds, Rank.Eight, 0),
+      Card.createCard(Suit.Diamonds, Rank.Six, 0),
+      Card.createCard(Suit.Clubs, Rank.Two, 0)
+    ];
+
+    console.log('=== AI Non-Trump Tractor Following Test ===');
+    console.log('Leading: 3♦3♦-4♦4♦ (Diamond tractor)');
+    console.log('Bot3 hand: A♦A♦, 7♦7♦, 8♦, 6♦, 2♣');
+    console.log('Expected: Bot3 should use A♦A♦7♦7♦ (all available pairs)');
+
+    const aiMove = getAIMove(gameState, PlayerId.Bot3);
+
+    console.log('AI selected:', aiMove.map(c => `${c.rank}${c.suit}`));
+
+    // Verify AI used all available pairs
+    expect(aiMove).toHaveLength(4);
+
+    // Count pairs used
+    const acePairs = aiMove.filter(c => c.rank === Rank.Ace).length;
+    const sevenPairs = aiMove.filter(c => c.rank === Rank.Seven).length;
+    const usedSingles = aiMove.filter(c => c.rank === Rank.Eight || c.rank === Rank.Six).length;
+
+    console.log('Ace pairs used:', acePairs);
+    console.log('Seven pairs used:', sevenPairs);
+    console.log('Singles used:', usedSingles);
+
+    // Should use BOTH available pairs (A♦A♦ and 7♦7♦)
+    expect(acePairs).toBe(2);
+    expect(sevenPairs).toBe(2);
+    expect(usedSingles).toBe(0); // Should NOT use singles when pairs available
+
+    console.log('✅ AI correctly uses ALL pairs before singles in non-trump tractor following');
+  });
+
+  it('should use all pairs + singles when insufficient pairs for full tractor', () => {
+    // Scenario: AI has only one pair but needs 4 cards
+    
+    const leadingTractor = [
+      Card.createCard(Suit.Diamonds, Rank.Three, 0),
+      Card.createCard(Suit.Diamonds, Rank.Three, 1),
+      Card.createCard(Suit.Diamonds, Rank.Four, 0),
+      Card.createCard(Suit.Diamonds, Rank.Four, 1)
+    ];
+
+    gameState.currentTrick = {
+      plays: [
+        { playerId: PlayerId.Bot2, cards: leadingTractor }
+      ],
+      winningPlayerId: PlayerId.Bot2,
+      points: 0
+    };
+
+    gameState.currentPlayerIndex = 3;
+    const bot3Player = gameState.players[3];
+
+    // Bot3 has only 1 pair available
+    bot3Player.hand = [
+      // Only 1 pair available
+      Card.createCard(Suit.Diamonds, Rank.Ace, 0),
+      Card.createCard(Suit.Diamonds, Rank.Ace, 1),
+      // Singles to complete
+      Card.createCard(Suit.Diamonds, Rank.Eight, 0),
+      Card.createCard(Suit.Diamonds, Rank.Six, 0),
+      Card.createCard(Suit.Clubs, Rank.Two, 0)
+    ];
+
+    console.log('\n=== Insufficient Pairs Scenario ===');
+    console.log('Bot3 has only 1 pair A♦A♦ for 4-card tractor');
+    console.log('Expected: A♦A♦ + 2 singles (8♦, 6♦)');
+
+    const aiMove = getAIMove(gameState, PlayerId.Bot3);
+
+    console.log('AI selected:', aiMove.map(c => `${c.rank}${c.suit}`));
+
+    expect(aiMove).toHaveLength(4);
+
+    // Should use the available pair
+    const acePairs = aiMove.filter(c => c.rank === Rank.Ace).length;
+    expect(acePairs).toBe(2);
+
+    // Should use singles to complete
+    const diamondSingles = aiMove.filter(c => 
+      c.suit === Suit.Diamonds && c.rank !== Rank.Ace
+    ).length;
+    expect(diamondSingles).toBe(2);
+
+    console.log('✅ AI correctly uses available pair + singles when insufficient pairs');
+  });
+
+  it('should not use valuable pairs when opponent is winning (strategic disposal)', () => {
+    // Test that AI applies strategic disposal even when following tractor rules
+    
+    const leadingTractor = [
+      Card.createCard(Suit.Diamonds, Rank.Three, 0),
+      Card.createCard(Suit.Diamonds, Rank.Three, 1),
+      Card.createCard(Suit.Diamonds, Rank.Four, 0),
+      Card.createCard(Suit.Diamonds, Rank.Four, 1)
+    ];
+
+    gameState.currentTrick = {
+      plays: [
+        { playerId: PlayerId.Human, cards: leadingTractor }  // Human (opponent) winning
+      ],
+      winningPlayerId: PlayerId.Human,
+      points: 0
+    };
+
+    gameState.currentPlayerIndex = 3;
+    const bot3Player = gameState.players[3];
+
+    // Bot3 has valuable vs non-valuable pairs
+    bot3Player.hand = [
+      // Valuable pairs (should avoid when opponent winning)
+      Card.createCard(Suit.Diamonds, Rank.Ace, 0),
+      Card.createCard(Suit.Diamonds, Rank.Ace, 1),
+      Card.createCard(Suit.Diamonds, Rank.King, 0),
+      Card.createCard(Suit.Diamonds, Rank.King, 1),
+      // Lower value pairs (should prefer)
+      Card.createCard(Suit.Diamonds, Rank.Seven, 0),
+      Card.createCard(Suit.Diamonds, Rank.Seven, 1),
+      Card.createCard(Suit.Diamonds, Rank.Eight, 0),
+      Card.createCard(Suit.Diamonds, Rank.Eight, 1),
+      Card.createCard(Suit.Clubs, Rank.Two, 0)
+    ];
+
+    console.log('\n=== Strategic Disposal Test ===');
+    console.log('Opponent winning, Bot3 has valuable pairs (A♦A♦, K♦K♦) and lower pairs (7♦7♦, 8♦8♦)');
+    console.log('Expected: Use lower value pairs (7♦7♦, 8♦8♦) when opponent winning');
+
+    const aiMove = getAIMove(gameState, PlayerId.Bot3);
+
+    console.log('AI selected:', aiMove.map(c => `${c.rank}${c.suit}`));
+
+    expect(aiMove).toHaveLength(4);
+
+    // Should avoid valuable pairs when opponent winning
+    const valuablePairs = aiMove.filter(c => c.rank === Rank.Ace || c.rank === Rank.King).length;
+    const lowPairs = aiMove.filter(c => c.rank === Rank.Seven || c.rank === Rank.Eight).length;
+
+    expect(valuablePairs).toBe(0); // Should NOT use valuable pairs
+    expect(lowPairs).toBe(4); // Should use lower value pairs
+
+    console.log('✅ AI correctly avoids valuable pairs when opponent winning');
+  });
+});

--- a/__tests__/game/gamePlayManager.test.ts
+++ b/__tests__/game/gamePlayManager.test.ts
@@ -24,6 +24,7 @@ import { createGameState } from '../helpers/gameStates';
 jest.mock('../../src/game/comboDetection', () => ({
   identifyCombos: jest.fn(),
   checkSameSuitPairPreservation: jest.fn(),
+  checkTractorFollowingPriority: jest.fn(),
   getComboType: jest.fn(),
 }));
 
@@ -227,6 +228,8 @@ describe('playProcessing', () => {
         
         // Mock checkSameSuitPairPreservation to return true
         (comboDetection.checkSameSuitPairPreservation as jest.Mock).mockReturnValue(true);
+        // Mock checkTractorFollowingPriority to return true
+        (comboDetection.checkTractorFollowingPriority as jest.Mock).mockReturnValue(true);
       });
 
       test('should validate a play when following a trick', () => {

--- a/__tests__/game/issue207TractorFollowing.test.ts
+++ b/__tests__/game/issue207TractorFollowing.test.ts
@@ -1,0 +1,153 @@
+import { isValidPlay } from '../../src/game/playValidation';
+import { Card, Suit, Rank, TrumpInfo } from '../../src/types';
+
+describe('Issue 207: Tractor Following Validation', () => {
+  let trumpInfo: TrumpInfo;
+
+  beforeEach(() => {
+    trumpInfo = {
+      trumpRank: Rank.Five,
+      trumpSuit: Suit.Hearts,
+    };
+  });
+
+  it('should reject invalid tractor following when pairs are available but not used', () => {
+    // Scenario from issue 207:
+    // Trump: 5♥
+    // Bot2 leads: 3♦3♦-4♦4♦ (Diamond tractor - 2 pairs)
+    // Human has: A♦A♦ (pair), 8♦, 7♦, 6♦ (singles)
+    // Human attempts: 8♦7♦7♦6♦ - should be INVALID
+
+    const leadingCombo = [
+      Card.createCard(Suit.Diamonds, Rank.Three, 0),
+      Card.createCard(Suit.Diamonds, Rank.Three, 1),
+      Card.createCard(Suit.Diamonds, Rank.Four, 0),
+      Card.createCard(Suit.Diamonds, Rank.Four, 1)
+    ];
+
+    const playerHand = [
+      // A♦ pair available
+      Card.createCard(Suit.Diamonds, Rank.Ace, 0),
+      Card.createCard(Suit.Diamonds, Rank.Ace, 1),
+      // Singles
+      Card.createCard(Suit.Diamonds, Rank.Eight, 0),
+      Card.createCard(Suit.Diamonds, Rank.Seven, 0),
+      Card.createCard(Suit.Diamonds, Rank.Seven, 1), // Second 7♦ to form potential pair
+      Card.createCard(Suit.Diamonds, Rank.Six, 0),
+      // Other cards
+      Card.createCard(Suit.Clubs, Rank.Two, 0)
+    ];
+
+    // Human attempts to play: 8♦7♦7♦6♦ (mixed: singles + pair)
+    const attemptedPlay = [
+      Card.createCard(Suit.Diamonds, Rank.Eight, 0),
+      Card.createCard(Suit.Diamonds, Rank.Seven, 0),
+      Card.createCard(Suit.Diamonds, Rank.Seven, 1),
+      Card.createCard(Suit.Diamonds, Rank.Six, 0)
+    ];
+
+    console.log('=== Issue 207 Test Scenario ===');
+    console.log('Leading combo: 3♦3♦-4♦4♦ (tractor with 2 pairs)');
+    console.log('Player hand: A♦A♦, 8♦, 7♦, 7♦, 6♦, 2♣');
+    console.log('Player attempts: 8♦7♦7♦6♦ (mixed: singles + one pair)');
+    console.log('Available A♦A♦ pair not used');
+    console.log('Expected: INVALID - must use ALL available pairs before singles');
+
+    const isValid = isValidPlay(attemptedPlay, leadingCombo, playerHand, trumpInfo);
+
+    console.log('Validation result:', isValid ? 'VALID' : 'INVALID');
+
+    if (isValid) {
+      console.log('❌ BUG CONFIRMED: Allows invalid tractor following');
+      console.log('Should reject play that mixes singles+pairs when more pairs available');
+    } else {
+      console.log('✅ CORRECT: Properly rejects invalid tractor following');
+    }
+
+    // Should be INVALID because player has A♦A♦ pair available but used mixed singles+pairs instead
+    expect(isValid).toBe(false);
+  });
+
+  it('should accept valid tractor following using all available pairs first', () => {
+    // Same scenario but player uses proper tractor following rules
+    
+    const leadingCombo = [
+      Card.createCard(Suit.Diamonds, Rank.Three, 0),
+      Card.createCard(Suit.Diamonds, Rank.Three, 1),
+      Card.createCard(Suit.Diamonds, Rank.Four, 0),
+      Card.createCard(Suit.Diamonds, Rank.Four, 1)
+    ];
+
+    const playerHand = [
+      // Available pairs
+      Card.createCard(Suit.Diamonds, Rank.Ace, 0),
+      Card.createCard(Suit.Diamonds, Rank.Ace, 1),
+      Card.createCard(Suit.Diamonds, Rank.Seven, 0),
+      Card.createCard(Suit.Diamonds, Rank.Seven, 1),
+      // Singles
+      Card.createCard(Suit.Diamonds, Rank.Eight, 0),
+      Card.createCard(Suit.Diamonds, Rank.Six, 0),
+      Card.createCard(Suit.Clubs, Rank.Two, 0)
+    ];
+
+    // Valid play: A♦A♦7♦7♦ (all pairs used first)
+    const validPlay = [
+      Card.createCard(Suit.Diamonds, Rank.Ace, 0),
+      Card.createCard(Suit.Diamonds, Rank.Ace, 1),
+      Card.createCard(Suit.Diamonds, Rank.Seven, 0),
+      Card.createCard(Suit.Diamonds, Rank.Seven, 1)
+    ];
+
+    console.log('\n=== Valid Tractor Following ===');
+    console.log('Player uses: A♦A♦7♦7♦ (all available pairs)');
+    console.log('Expected: VALID - proper tractor following with pairs');
+
+    const isValid = isValidPlay(validPlay, leadingCombo, playerHand, trumpInfo);
+
+    console.log('Validation result:', isValid ? 'VALID' : 'INVALID');
+
+    // Should be VALID because player uses all available pairs
+    expect(isValid).toBe(true);
+  });
+
+  it('should accept mixed play when insufficient pairs for full tractor', () => {
+    // Player has only 1 pair but tractor requires 2 pairs
+    
+    const leadingCombo = [
+      Card.createCard(Suit.Diamonds, Rank.Three, 0),
+      Card.createCard(Suit.Diamonds, Rank.Three, 1),
+      Card.createCard(Suit.Diamonds, Rank.Four, 0),
+      Card.createCard(Suit.Diamonds, Rank.Four, 1)
+    ];
+
+    const playerHand = [
+      // Only 1 pair available  
+      Card.createCard(Suit.Diamonds, Rank.Ace, 0),
+      Card.createCard(Suit.Diamonds, Rank.Ace, 1),
+      // Singles
+      Card.createCard(Suit.Diamonds, Rank.Eight, 0),
+      Card.createCard(Suit.Diamonds, Rank.Six, 0),
+      Card.createCard(Suit.Clubs, Rank.Two, 0)
+    ];
+
+    // Valid play: A♦A♦8♦6♦ (use available pair + singles)
+    const validPlay = [
+      Card.createCard(Suit.Diamonds, Rank.Ace, 0),
+      Card.createCard(Suit.Diamonds, Rank.Ace, 1),
+      Card.createCard(Suit.Diamonds, Rank.Eight, 0),
+      Card.createCard(Suit.Diamonds, Rank.Six, 0)
+    ];
+
+    console.log('\n=== Insufficient Pairs Scenario ===');
+    console.log('Player has only 1 pair A♦A♦ for 4-card tractor lead');
+    console.log('Player uses: A♦A♦8♦6♦ (available pair + singles)');
+    console.log('Expected: VALID - uses all available pairs');
+
+    const isValid = isValidPlay(validPlay, leadingCombo, playerHand, trumpInfo);
+
+    console.log('Validation result:', isValid ? 'VALID' : 'INVALID');
+
+    // Should be VALID because player uses their only available pair
+    expect(isValid).toBe(true);
+  });
+});

--- a/src/game/playValidation.ts
+++ b/src/game/playValidation.ts
@@ -2,6 +2,7 @@ import { Card, ComboType, TrumpInfo } from "../types";
 import {
   identifyCombos,
   checkSameSuitPairPreservation,
+  checkTractorFollowingPriority,
   getComboType,
 } from "./comboDetection";
 import { isTrump } from "./gameHelpers";
@@ -227,6 +228,18 @@ export const isValidPlay = (
 
     // Issue #126 Fix: Also check same-suit pair preservation
     if (allLeadingSuit) {
+      // Issue #207 Fix: Check tractor following priority (pairs before singles)
+      if (
+        !checkTractorFollowingPriority(
+          playedCards,
+          leadingCombo,
+          playerHand,
+          trumpInfo,
+        )
+      ) {
+        return false;
+      }
+
       return checkSameSuitPairPreservation(
         playedCards,
         leadingCombo,
@@ -285,6 +298,18 @@ export const isValidPlay = (
 
     // Issue #126 Fix: Also check same-suit pair preservation for partial suit following
     if (allPlayedFromHand) {
+      // Issue #207 Fix: Check tractor following priority for partial suit following
+      if (
+        !checkTractorFollowingPriority(
+          playedCards,
+          leadingCombo,
+          playerHand,
+          trumpInfo,
+        )
+      ) {
+        return false;
+      }
+
       return checkSameSuitPairPreservation(
         playedCards,
         leadingCombo,


### PR DESCRIPTION
## Summary
- Fix validation to enforce fundamental tractor rule: when following pairs/tractors, must use ALL available pairs before any singles
- Add comprehensive test coverage for both validation and AI behavior  
- Resolves issue #207: Game incorrectly allows invalid tractor following

## Changes Made
- **New function**: `checkTractorFollowingPriority()` in `comboDetection.ts` enforces pair-before-singles rule
- **Validation integration**: Updated `playValidation.ts` to use new validation in Cases 3 and 4
- **Comprehensive tests**: Added validation tests reproducing the bug and verifying the fix
- **AI behavior tests**: Confirmed AI properly follows the pair priority rule

## Test Coverage
- ✅ Validation correctly rejects invalid plays (using singles when pairs available)
- ✅ Validation accepts valid plays (using all available pairs first)  
- ✅ AI follows proper tractor hierarchy in non-trump following scenarios
- ✅ All existing tests continue to pass

## Technical Details
The fix addresses a fundamental game rule violation where players could play singles while having available pairs when following tractors. The new validation function ensures proper tractor following hierarchy is maintained throughout the game.

🤖 Generated with [Claude Code](https://claude.ai/code)