### PR TITLE
Fix: Use correct namedLogo parameter for Jest icon

### DIFF
--- a/.github/workflows/eas-update.yml
+++ b/.github/workflows/eas-update.yml
@@ -56,7 +56,7 @@ jobs:
         label: Tests
         message: ${{ steps.tests.outputs.test_count }} Passing
         color: brightgreen
-        logo: jest
+        namedLogo: jest
 
     - name: Setup Expo
       uses: expo/expo-github-action@v8


### PR DESCRIPTION
## Summary
Fix workflow warning by using the correct parameter name for the Jest logo in Dynamic Badges Action.

## Issue
The workflow showed a warning about unexpected input 'logo' parameter.

## Fix
- Change logo parameter to namedLogo in EAS workflow
- Removes the warning while maintaining Jest icon display
- Follows the correct Dynamic Badges Action parameter specification

## Test plan
- Workflow runs without warnings
- Badge continues to display Jest icon properly
- Test count extraction remains functional