### PR TITLE
Fix: Eliminate duplicate round_start logging

### DIFF
--- a/__tests__/game/gameRoundManager.test.ts
+++ b/__tests__/game/gameRoundManager.test.ts
@@ -7,13 +7,14 @@ import {
   Suit,
   TeamId
 } from "../../src/types";
-import { initializeGame } from '../../src/utils/gameInitialization';
+import { createDeck, shuffleDeck } from '../../src/utils/gameInitialization';
 import { createFullGameStateWithTricks } from "../helpers";
 
 // Mock dependencies
 jest.mock('../../src/utils/gameInitialization', () => ({
   ...jest.requireActual('../../src/utils/gameInitialization'),
-  initializeGame: jest.fn()
+  createDeck: jest.fn(),
+  shuffleDeck: jest.fn()
 }));
 
 const createMockGameState = createFullGameStateWithTricks;
@@ -27,7 +28,7 @@ describe('gameRoundManager', () => {
     test('should correctly prepare the game state for the next round', () => {
       const mockState = createMockGameState();
       
-      // Mock the return value of initializeGame to return a deck
+      // Mock the return value of createDeck and shuffleDeck to return a specific deck
       const mockDeck = Array(52).fill(null).map((_, i) => ({
         id: `card_${i}`,
         suit: Suit.Spades,
@@ -36,9 +37,8 @@ describe('gameRoundManager', () => {
         joker: undefined
       }));
       
-      (initializeGame as jest.Mock).mockReturnValue({
-        deck: mockDeck
-      });
+      (createDeck as jest.Mock).mockReturnValue(mockDeck);
+      (shuffleDeck as jest.Mock).mockReturnValue(mockDeck);
       
       // Create a mock round result for testing prepareNextRound
       const mockRoundResult = {
@@ -91,8 +91,9 @@ describe('gameRoundManager', () => {
       // Verify dealing state was reset
       expect(result.dealingState).toBeUndefined();
       
-      // Verify initializeGame was called
-      expect(initializeGame).toHaveBeenCalled();
+      // Verify createDeck and shuffleDeck were called
+      expect(createDeck).toHaveBeenCalled();
+      expect(shuffleDeck).toHaveBeenCalledWith(mockDeck);
     });
   });
 

--- a/src/game/gameRoundManager.ts
+++ b/src/game/gameRoundManager.ts
@@ -1,5 +1,6 @@
 import {
-  initializeGame,
+  createDeck,
+  shuffleDeck,
   initializeTrumpDeclarationState,
 } from "../utils/gameInitialization";
 import { GamePhase, GameState, Rank, RoundResult, TeamId } from "../types";
@@ -99,7 +100,7 @@ export function prepareNextRound(
   }
 
   // Create and shuffle a new deck
-  const deck = initializeGame().deck;
+  const deck = shuffleDeck(createDeck());
 
   newState.deck = deck;
 

--- a/src/utils/gameInitialization.ts
+++ b/src/utils/gameInitialization.ts
@@ -135,9 +135,9 @@ export const initializeGame = (): GameState => {
     gamePhase: GamePhase.Dealing,
   };
 
-  // Log the start of round 1
+  // Log game initialization
   gameLogger.debug(
-    "round_start",
+    "game_initialized",
     {
       roundNumber: gameState.roundNumber,
       defendingTeam: gameState.teams.find((t) => t.isDefending)?.id,
@@ -150,8 +150,9 @@ export const initializeGame = (): GameState => {
         currentRank: team.currentRank,
         isDefending: team.isDefending,
       })),
+      deckSize: gameState.deck.length,
     },
-    `Round ${gameState.roundNumber} started: ${gameState.teams.find((t) => t.isDefending)?.id} defending, ${gameState.teams.find((t) => !t.isDefending)?.id} attacking, trump rank ${gameState.trumpInfo.trumpRank}`,
+    `Game initialized: ${gameState.teams.find((t) => t.isDefending)?.id} defending, ${gameState.teams.find((t) => !t.isDefending)?.id} attacking, trump rank ${gameState.trumpInfo.trumpRank}`,
   );
 
   return gameState;


### PR DESCRIPTION
## Summary

• Fixed duplicate "round_start" logs by removing initializeGame() call from prepareNextRound()
• Changed initialization logging from "round_start" to "game_initialized" for better clarity
• Updated tests to mock createDeck/shuffleDeck instead of full initializeGame()
• Added deckSize to game initialization logging data

## Test plan

- [x] All 712 tests pass
- [x] TypeScript compilation passes with zero errors
- [x] ESLint passes with zero warnings
- [x] No more duplicate "round_start" logs in game flow
- [x] Clean separation: game_initialized vs round_start events

🤖 Generated with [Claude Code](https://claude.ai/code)