### PR TITLE
fix: Remove premature trump declaration bonus to improve AI timing

### DIFF
--- a/src/ai/trumpDeclaration/trumpDeclarationStrategy.ts
+++ b/src/ai/trumpDeclaration/trumpDeclarationStrategy.ts
@@ -190,7 +190,7 @@ function getCurrentDeclarationMultiplier(
   proposedDeclaration: { type: DeclarationType },
 ): number {
   if (!currentDeclaration) {
-    return 1.2; // Strong bonus when no one has declared yet - establish early control
+    return 1.0; // Neutral when no one has declared - wait for better information
   }
 
   const currentStrength = getDeclarationStrength(currentDeclaration.type);


### PR DESCRIPTION
## Summary

• Remove counterproductive 1.2x bonus that encouraged premature trump declarations
• AI now uses neutral timing when no one has declared trump yet
• Improves strategic decision-making by waiting for better hand information

## Problem

The AI was declaring trump too early in the dealing process due to a 1.2x "early control" bonus when no one else had declared. This led to:

- Premature declarations with incomplete hand information
- Higher vulnerability to override by stronger later declarations  
- Suboptimal trump suit selection

## Solution

- Changed bonus from 1.2x to neutral 1.0x multiplier
- AI now waits for better information before committing to trump
- Maintains strategic patience while still allowing competitive overrides

## Test plan

- [x] Verify AI declaration timing is more conservative
- [x] Test that AI still declares strong hands (pairs, jokers) appropriately
- [x] Confirm override logic still works for competitive situations

🤖 Generated with [Claude Code](https://claude.ai/code)