### PR TITLE
Enhance EAS Build Workflow with Manual Trigger Support

### DIFF
--- a/.github/actions/git-version/action.yml
+++ b/.github/actions/git-version/action.yml
@@ -72,7 +72,7 @@ runs:
           # Main branch push - isolate with git hash in runtime version
           VERSION="v${BASE_VERSION}-beta.${COMMIT_COUNT}"
           FULL_VERSION="v${BASE_VERSION}-beta.${COMMIT_COUNT}+${GIT_HASH_SHORT}"
-          RUNTIME_VERSION="v${BASE_VERSION}-beta.${COMMIT_COUNT}+${GIT_HASH_SHORT}"
+          RUNTIME_VERSION="v${BASE_VERSION}-beta"
           EAS_BRANCH="beta"
           
         else

--- a/.github/workflows/eas-build-apk.yml
+++ b/.github/workflows/eas-build-apk.yml
@@ -3,6 +3,13 @@ name: EAS Build APK
 on:
   release:
     types: [released]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git reference (tag, branch, or commit SHA) to build'
+        required: true
+        default: 'main'
+        type: string
 
 permissions:
   contents: write
@@ -16,6 +23,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
       with:
+        ref: ${{ github.event.inputs.ref || github.event.release.tag_name || github.sha }}
         fetch-depth: 0
 
     - name: Setup Node.js
@@ -53,10 +61,12 @@ jobs:
         echo "Build URL: $BUILD_URL"
 
     - name: Download APK
+      if: github.event_name == 'release'
       run: |
         curl -L -o tractor-${{ steps.version.outputs.version }}.apk "${{ steps.build-url.outputs.build_url }}"
 
     - name: Upload APK to Release
+      if: github.event_name == 'release'
       uses: softprops/action-gh-release@v2
       with:
         files: tractor-${{ steps.version.outputs.version }}.apk


### PR DESCRIPTION
## Summary

- Add manual trigger capability to EAS Build APK workflow with custom ref input
- Optimize workflow behavior for different trigger types (manual vs release)
- Improve version detection for beta builds

## Changes Made

### Workflow Enhancements
- **Manual Trigger Support**: Add `workflow_dispatch` trigger with `ref` input parameter
- **Flexible Reference Selection**: Support building from any tag, branch, or commit SHA
- **Smart Checkout Logic**: Use release tag for releases, input ref for manual triggers
- **Conditional Steps**: Skip download/upload for manual builds (testing only)

### Version System Improvements  
- **Explicit Release Reference**: Use `github.event.release.tag_name` for release builds
- **Simplified Beta Runtime**: Clean `v{version}-beta` format without commit details
- **Maintained Compatibility**: Preserve detailed version info in full version string

## Benefits

### For Developers
- **Testing Builds**: Manually trigger builds from any branch/tag for validation
- **No Release Overhead**: Manual builds skip unnecessary download/upload steps
- **Flexible Deployment**: Test builds from feature branches or specific commits

### For Production
- **Unchanged Release Flow**: Existing release automation remains intact
- **Clean Runtime Versions**: Beta builds use stable runtime version format
- **Proper Isolation**: Beta and production builds properly separated

## Technical Details

**Manual Trigger Usage:**
1. Go to GitHub Actions → EAS Build APK workflow
2. Click "Run workflow"
3. Enter desired git reference (tag, branch, or commit SHA)
4. Build creates APK on EAS (accessible via EAS dashboard)

**Version Detection:**
- **Release builds**: Use actual release tag version
- **Main branch**: `v{base}-beta.{count}` with clean `v{base}-beta` runtime
- **Feature branches**: `v{base}-alpha.{count}` with isolated runtime

🤖 Generated with [Claude Code](https://claude.ai/code)