### PR TITLE
Fix: Pin Expo and EAS CLI Versions for Stable Builds

### DIFF
--- a/.github/workflows/eas-build-apk.yml
+++ b/.github/workflows/eas-build-apk.yml
@@ -41,8 +41,8 @@ jobs:
     - name: Setup Expo
       uses: expo/expo-github-action@v8
       with:
-        expo-version: latest
-        eas-version: latest
+        expo-version: 53.0.11
+        eas-version: 16.10.1
         token: ${{ secrets.EXPO_TOKEN }}
 
     - name: Detect version and inject into app.json

--- a/eas.json
+++ b/eas.json
@@ -1,6 +1,6 @@
 {
   "cli": {
-    "version": ">= 16.6.0",
+    "version": ">= 16.10.1",
     "appVersionSource": "remote"
   },
   "build": {


### PR DESCRIPTION
## Summary

- Pin Expo and EAS CLI versions in build workflow to resolve dependency conflicts
- Update eas.json version requirements for consistency

## Problem

The build workflow was using `latest` versions for Expo and EAS CLI, which caused:
- Jest dependency conflicts during `npm ci`
- Unpredictable build failures when new versions were released
- Inconsistent builds across different runs

## Solution

### Workflow Changes
- **Pin expo-version**: `53.0.11` (matches project's Expo SDK)
- **Pin eas-version**: `16.10.1` (latest stable CLI version)
- **Remove 'latest' versions**: Prevents unexpected breaking changes

### Configuration Updates
- **Update eas.json**: Minimum version `>= 16.10.1` for team consistency
- **Maintain compatibility**: Versions align with project requirements

## Benefits

### Stability
- **Reproducible builds**: Same versions every time
- **No surprise failures**: Updates are controlled and intentional
- **Faster debugging**: Consistent environment for troubleshooting

### Team Development
- **Version consistency**: Local and CI use compatible tool versions
- **Clear requirements**: Minimum EAS CLI version specified in eas.json
- **Better DX**: Developers know exactly which versions to use

## Testing

- Workflow maintains same functionality with stable, pinned versions
- Quality checks continue to use project's locked dependencies
- Build process remains unchanged, just more reliable

🤖 Generated with [Claude Code](https://claude.ai/code)