### PR TITLE
Fix AI void-aware point leading and enhance build pipeline

### DIFF
--- a/.github/workflows/eas-build-apk.yml
+++ b/.github/workflows/eas-build-apk.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: 'Git reference (tag, branch, or commit SHA) to build'
+        description: 'Git reference to build (main branch or version tag like v1.2.3)'
         required: true
         default: 'main'
         type: string
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   build:
-    name: Build Production APK
+    name: Build APK
     runs-on: ubuntu-latest
     
     steps:
@@ -49,10 +49,31 @@ jobs:
       id: version
       uses: ./.github/actions/git-version
 
+    - name: Determine build profile from version
+      id: profile
+      run: |
+        EAS_BRANCH="${{ steps.version.outputs.eas-branch }}"
+        case "$EAS_BRANCH" in
+          "production")
+            echo "profile=production" >> $GITHUB_OUTPUT
+            echo "Using production profile for production version"
+            ;;
+          "beta")
+            echo "profile=preview" >> $GITHUB_OUTPUT
+            echo "Using preview profile for beta version (main branch)"
+            ;;
+          *)
+            echo "profile=development" >> $GITHUB_OUTPUT
+            echo "Using development profile for branch: $EAS_BRANCH"
+            ;;
+        esac
+
     - name: Build APK
-      run: eas build --platform android --profile production --non-interactive --wait
+      if: steps.profile.outputs.profile == 'production' || steps.profile.outputs.profile == 'preview'
+      run: eas build --platform android --profile ${{ steps.profile.outputs.profile }} --non-interactive --wait
 
     - name: Get build artifact URL
+      if: steps.profile.outputs.profile == 'production' || steps.profile.outputs.profile == 'preview'
       id: build-url
       run: |
         # Get the latest build for this project

--- a/eas.json
+++ b/eas.json
@@ -9,7 +9,15 @@
       "distribution": "internal"
     },
     "preview": {
-      "distribution": "internal"
+      "distribution": "internal",
+      "channel": "preview",
+      "android": {
+        "buildType": "apk",
+        "gradleCommand": ":app:assembleRelease"
+      },
+      "env": {
+        "NODE_ENV": "production"
+      }
     },
     "production": {
       "channel": "production",


### PR DESCRIPTION
## Summary

This PR addresses two major improvements:

### 🤖 AI Point Card Protection
- **Fixed void-unaware point leading issue** - AI was leading non-trump point cards when opponents had voids in that suit
- **Added intelligent point card protection** that filters risky leads before other priorities
- **Protects valuable cards (5+ points)** from being captured by opponent trump cards
- **Replaced hardcoded teammate detection** with dynamic game state-based logic using player team assignments
- **Maintains existing void exploitation** while adding protective intelligence

### 🔧 Build Pipeline Enhancements
- **Enhanced preview profile** with preview channel, APK build configuration, and production optimizations
- **Added smart profile detection** based on git context: production → production, beta → preview, alpha → development  
- **Added conditional building** to only build APKs for production and preview profiles (skips development builds)
- **Aligned build profiles with update channels** for proper OTA delivery

### ⚙️ Configuration Updates
- **Updated eas.json** preview profile with channel, Android APK build, and NODE_ENV=production
- **Enhanced build workflow** with version-based profile detection and conditional execution
- **Streamlined profile logic** with development as safe fallback

## Test Plan

- [x] All quality checks pass (typecheck, lint, tests)
- [x] AI leading strategy properly filters risky point cards
- [x] Build pipeline correctly detects profiles based on git context
- [x] Preview builds get production optimizations with preview updates

🤖 Generated with [Claude Code](https://claude.ai/code)