### PR TITLE
Fix: AI Point Card Protection & GitHub Workflow Updates

### DIFF
--- a/.github/workflows/eas-build-apk.yml
+++ b/.github/workflows/eas-build-apk.yml
@@ -41,8 +41,8 @@ jobs:
     - name: Setup Expo
       uses: expo/expo-github-action@v8
       with:
-        expo-version: 53.0.11
         eas-version: 16.10.1
+        packager: npm
         token: ${{ secrets.EXPO_TOKEN }}
 
     - name: Detect version and inject into app.json

--- a/.github/workflows/eas-build-apk.yml
+++ b/.github/workflows/eas-build-apk.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: 'Git reference (tag, branch, or commit SHA) to build'
+        description: 'Git reference to build (main branch or version tag like v1.2.3)'
         required: true
         default: 'main'
         type: string
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   build:
-    name: Build Production APK
+    name: Build APK
     runs-on: ubuntu-latest
     
     steps:
@@ -49,10 +49,31 @@ jobs:
       id: version
       uses: ./.github/actions/git-version
 
+    - name: Determine build profile from version
+      id: profile
+      run: |
+        EAS_BRANCH="${{ steps.version.outputs.eas-branch }}"
+        case "$EAS_BRANCH" in
+          "production")
+            echo "profile=production" >> $GITHUB_OUTPUT
+            echo "Using production profile for production version"
+            ;;
+          "beta")
+            echo "profile=preview" >> $GITHUB_OUTPUT
+            echo "Using preview profile for beta version (main branch)"
+            ;;
+          *)
+            echo "profile=development" >> $GITHUB_OUTPUT
+            echo "Using development profile for branch: $EAS_BRANCH"
+            ;;
+        esac
+
     - name: Build APK
-      run: eas build --platform android --profile production --non-interactive --wait
+      if: steps.profile.outputs.profile == 'production' || steps.profile.outputs.profile == 'preview'
+      run: eas build --platform android --profile ${{ steps.profile.outputs.profile }} --non-interactive --wait
 
     - name: Get build artifact URL
+      if: steps.profile.outputs.profile == 'production' || steps.profile.outputs.profile == 'preview'
       id: build-url
       run: |
         # Get the latest build for this project

--- a/.github/workflows/eas-update.yml
+++ b/.github/workflows/eas-update.yml
@@ -61,8 +61,8 @@ jobs:
     - name: Setup Expo
       uses: expo/expo-github-action@v8
       with:
-        expo-version: latest
-        eas-version: latest
+        eas-version: 16.10.1
+        packager: npm
         token: ${{ secrets.EXPO_TOKEN }}
 
     - name: Detect version and inject into app.json

--- a/eas.json
+++ b/eas.json
@@ -9,7 +9,15 @@
       "distribution": "internal"
     },
     "preview": {
-      "distribution": "internal"
+      "distribution": "internal",
+      "channel": "preview",
+      "android": {
+        "buildType": "apk",
+        "gradleCommand": ":app:assembleRelease"
+      },
+      "env": {
+        "NODE_ENV": "production"
+      }
     },
     "production": {
       "channel": "production",


### PR DESCRIPTION
## Summary
- Fix AI leading non-trump point cards when opponents have suit voids
- Update GitHub workflows to remove invalid parameters and improve reproducibility

## Changes Made

### AI Point Card Protection
- Added Priority 2.5 point card protection logic to leading strategy
- Implemented risk assessment for non-trump point cards (5+ points)
- Added dynamic game state-based teammate detection
- Filtered risky leads while maintaining graceful fallback

### GitHub Workflow Fixes
- Removed invalid `expo-version` parameter from expo-github-action
- Added explicit `packager: npm` for consistency with project setup
- Changed `eas-version` from `latest` to `16.10.1` for reproducibility

## Test Plan
- [x] Quality checks pass (lint, typecheck, tests)
- [x] AI no longer leads valuable point cards into opponent voids
- [x] GitHub workflows should now execute without expo-cli resolution errors
- [x] Build pipeline correctly detects profiles and channels

🤖 Generated with [Claude Code](https://claude.ai/code)