### PR TITLE
Adjust trump declaration suit length thresholds for better AI timing

### DIFF
--- a/src/ai/trumpDeclaration/trumpDeclarationStrategy.ts
+++ b/src/ai/trumpDeclaration/trumpDeclarationStrategy.ts
@@ -171,11 +171,11 @@ function suitMeetsThresholds(
 ): boolean {
   // Progressive suit length requirements based on timing
   if (progressRatio < 0.3) {
-    return suitLength >= 6; // Early (0-30%): need exceptional suit
+    return suitLength >= 4; // Early (0-30%): need exceptional suit
   } else if (progressRatio < 0.7) {
-    return suitLength >= 8; // Mid (30-70%): need good suit
+    return suitLength >= 5; // Mid (30-70%): need good suit
   } else {
-    return suitLength >= 7; // Late (70-100%): acceptable suit
+    return suitLength >= 6; // Late (70-100%): acceptable suit
   }
 }
 


### PR DESCRIPTION
## Summary
- Reduce suit length requirements for trump declarations across all timing phases
- Enable more active AI trump declarations while maintaining strategic timing
- Fix overly conservative thresholds that blocked viable declaration opportunities

## Changes
- **Early phase (0-30%)**: 6 → 4 cards minimum
- **Mid phase (30-70%)**: 8 → 5 cards minimum  
- **Late phase (70-100%)**: 7 → 6 cards minimum

## Rationale
The previous thresholds were too restrictive and caused AI players to miss viable declaration opportunities. These adjustments:

- **Enable Earlier Declarations**: 4-card suits can be viable for early aggressive declarations
- **Improve Mid-Game Activity**: 5-card suits represent reasonable declaration strength
- **Maintain Late-Game Standards**: 6-card minimum still ensures quality late declarations

## Impact
- AI players will declare trump more frequently when they have reasonable suits
- Better utilization of declaration opportunities during progressive dealing
- Maintains strategic timing principles while being less conservative
- Should improve overall game dynamics and AI competitiveness

## Test Plan
- [ ] Verify AI makes more frequent trump declarations
- [ ] Confirm declarations still follow timing-based strategy
- [ ] Ensure declaration quality remains reasonable
- [ ] Test impact on overall game balance

🤖 Generated with [Claude Code](https://claude.ai/code)