### PR TITLE
Fix: Allow trump responses to multi-combos (#259)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 @README.md
 @docs/AI_SYSTEM.md
 @docs/GAME_RULES.md
+@docs/MULTI_COMBO_SYSTEM_ARCHITECTURE.md
+@docs/MULTI_COMBO_ALGORITHMS.md
 
 ## Project Overview
 
@@ -12,7 +14,7 @@ Tractor is a React Native Expo app implementing a single-player version of the C
 
 **Platform Support:** Mobile-only (iOS and Android). Currently tested on Android only.
 
-*Game details in [Game Rules](docs/GAME_RULES.md) | AI system in [AI System](docs/AI_SYSTEM.md)*
+*Game details in [Game Rules](docs/GAME_RULES.md) | AI system in [AI System](docs/AI_SYSTEM.md) | Multi-combo system in [Architecture](docs/MULTI_COMBO_SYSTEM_ARCHITECTURE.md) & [Algorithms](docs/MULTI_COMBO_ALGORITHMS.md)*
 
 ## 🚨 CRITICAL MULTI-COMBO UNDERSTANDING 🚨
 
@@ -58,7 +60,7 @@ A combo is "unbeatable" when **ALL OTHER THREE PLAYERS COMBINED** cannot beat it
 
 ## 🚨 CRITICAL MULTI-COMBO VALIDATION UNDERSTANDING 🚨
 
-**For Development Context Only** - Detailed implementation in [Multi-Combo Algorithms](docs/MULTI_COMBO_ALGORITHMS.md)
+**For Development Context Only** - Complete system documentation in [Multi-Combo Architecture](docs/MULTI_COMBO_SYSTEM_ARCHITECTURE.md) and [Multi-Combo Algorithms](docs/MULTI_COMBO_ALGORITHMS.md)
 
 ### **Key Developer Insights**
 - **Exhaustion Rule**: Mixed-suit plays can be valid when player exhausts relevant suit

--- a/docs/AI_SYSTEM.md
+++ b/docs/AI_SYSTEM.md
@@ -2,7 +2,7 @@
 
 **Comprehensive AI Intelligence & Strategic Decision Making**
 
-*Related Documentation: [Game Rules](GAME_RULES.md) | [CLAUDE.md](../CLAUDE.md)*
+*Related Documentation: [Game Rules](GAME_RULES.md) | [Multi-Combo Architecture](MULTI_COMBO_SYSTEM_ARCHITECTURE.md) | [Multi-Combo Algorithms](MULTI_COMBO_ALGORITHMS.md) | [CLAUDE.md](../CLAUDE.md)*
 
 ## Overview
 
@@ -571,4 +571,6 @@ The AI system successfully balances **strategic sophistication** with **enjoyabl
 **See Also:**
 
 - **[Game Rules](GAME_RULES.md)** - Complete Tractor/Shengji rules and strategy guide
+- **[Multi-Combo Architecture](MULTI_COMBO_SYSTEM_ARCHITECTURE.md)** - Comprehensive multi-combo system architecture and integration
+- **[Multi-Combo Algorithms](MULTI_COMBO_ALGORITHMS.md)** - Detailed multi-combo leading and following algorithms
 - **[CLAUDE.md](../CLAUDE.md)** - Development guidelines and project architecture

--- a/docs/MULTI_COMBO_ALGORITHMS.md
+++ b/docs/MULTI_COMBO_ALGORITHMS.md
@@ -2,7 +2,7 @@
 
 **Comprehensive Multi-Combo Leading and Following Logic**
 
-*Related Documentation: [Game Rules](GAME_RULES.md) | [AI System](AI_SYSTEM.md) | [CLAUDE.md](../CLAUDE.md)*
+*Related Documentation: [Game Rules](GAME_RULES.md) | [AI System](AI_SYSTEM.md) | [Multi-Combo Architecture](MULTI_COMBO_SYSTEM_ARCHITECTURE.md) | [CLAUDE.md](../CLAUDE.md)*
 
 ---
 

--- a/src/game/cardComparison.ts
+++ b/src/game/cardComparison.ts
@@ -137,7 +137,11 @@ export function evaluateTrickPlay(
   const currentWinningCombo = getCurrentWinningCombo(currentTrick);
 
   // Step 1: Validate combo type matching
-  if (leadingComboType !== proposedComboType) {
+  // Allow trump responses to multi-combos (when leadingComboType is Invalid)
+  if (
+    leadingComboType !== proposedComboType &&
+    leadingComboType !== ComboType.Invalid
+  ) {
     return {
       canBeat: false,
       isLegal: false,


### PR DESCRIPTION
## Summary
- Fixed GitHub issue #259: Multi-combo trump beat non-trump issue
- Resolves validation logic preventing trump pairs from beating non-trump multi-combos
- Added comprehensive unit test reproducing the exact bug scenario

## Root Cause
In `evaluateTrickPlay`, `getComboType` returns `ComboType.Invalid` for multi-combos, but the validation logic was incorrectly rejecting trump responses because `Invalid \!== Pair`.

## Solution
Added condition `&& leadingComboType \!== ComboType.Invalid` to allow trump responses to multi-combos while preserving all existing functionality.

## Test Coverage
- New test: "Trump pair should beat non-trump multi-combo (A♠, K♠)"
- Reproduces exact GitHub issue scenario with trump 10♥-10♥ vs non-trump A♠, K♠
- All 869 existing tests continue to pass

## Files Changed
- `src/game/cardComparison.ts`: Fixed validation logic (lines 141-144)
- `__tests__/game/evaluateTrickPlay.test.ts`: Added comprehensive test case

🤖 Generated with [Claude Code](https://claude.ai/code)