### PR TITLE
feat: Improve Chinese App Title Spacing

### DIFF
--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -1,5 +1,5 @@
 {
-  "appTitle": "八十分·升级游戏",
+  "appTitle": "八十分 · 升级游戏",
   "buttons": {
     "playCards": "出{{count}}张牌",
     "playCards_plural": "出{{count}}张牌",


### PR DESCRIPTION
## Summary
- Improved Chinese app title formatting with proper spacing around the middle dot (·)
- Enhanced typography and readability for Chinese users

## Changes
- Updated `src/locales/zh/common.json` with proper spacing: `八十分 · 升级游戏`

## Test plan
- [x] Verify Chinese localization displays correctly
- [x] Confirm spacing appears properly in app title
- [x] Check typography consistency with design standards

🤖 Generated with [Claude Code](https://claude.ai/code)