### PR TITLE
feat: Improve weak multi-combo leading logic

### DIFF
--- a/docs/AI_SYSTEM.md
+++ b/docs/AI_SYSTEM.md
@@ -382,6 +382,14 @@ The AI adapts its strategy based on trick position, leveraging unique advantages
 - **Information Management** - Balance between learning and hand concealment
 - **Point Collection Priority** - Aces and Kings before tractors when guaranteed
 
+#### **Weak Multi-Combo Leading**
+
+The AI uses a context-aware approach to leading weak multi-combos (e.g., two or three small, non-point singles). This prevents the AI from making risky, low-value leads in critical game situations.
+
+**Decision Logic:**
+- **Attacking Team**: The AI will lead a weak multi-combo to probe for opponent responses and gain information.
+- **Defending Team**: The AI will only lead a weak multi-combo when the `pointPressure` is `LOW`. This ensures the defending team plays conservatively and avoids giving up the lead unnecessarily when the attacking team is close to winning.
+
 ### **Following Player Strategy**
 
 All following positions use the same priority framework but with position-specific tactical advantages:

--- a/src/ai/leading/multiComboLeadingStrategy.ts
+++ b/src/ai/leading/multiComboLeadingStrategy.ts
@@ -5,8 +5,9 @@ import {
   checkOpponentVoidStatus,
   isComboUnbeatable,
 } from "../../game/multiComboValidation";
-import { Card, GameState, PlayerId, Suit } from "../../types";
+import { Card, GameState, PlayerId, PointPressure, Suit } from "../../types";
 import { createCardMemory } from "../aiCardMemory";
+import { createGameContext } from "../aiGameContext";
 
 /**
  * Multi-Combo Leading Strategy for AI
@@ -68,21 +69,12 @@ export function selectAIMultiComboLead(
         return mostUnbeatableCards;
       }
 
-      // If we have a weak multi-combo (only small singles), determine by game stage and role
-      let weakComboChance = 0;
-      const cardsLeft = playerHand.length;
-
-      if (cardsLeft > 18) {
-        weakComboChance = 1;
-      } else if (cardsLeft > 12) {
-        weakComboChance = 0.7;
-      } else if (cardsLeft > 6) {
-        weakComboChance = 0.5;
-      } else {
-        weakComboChance = 0.2;
-      }
-
-      if (Math.random() < weakComboChance) {
+      // If we have a weak multi-combo (only small singles), decide based on game context
+      const context = createGameContext(gameState, playerId);
+      if (
+        context.isAttackingTeam ||
+        context.pointPressure === PointPressure.LOW
+      ) {
         return mostUnbeatableCards;
       }
     }


### PR DESCRIPTION
- Replaced random chance with a context-aware approach for leading weak multi-combos.\n- The AI now only leads weak multi-combos when on the attacking team or when point pressure is low.\n- Updated documentation to reflect the new logic.