### PR TITLE
AI: Improve aggressive leading strategy

### DIFF
--- a/src/ai/aiCardMemory.ts
+++ b/src/ai/aiCardMemory.ts
@@ -1709,6 +1709,8 @@ export function enhanceGameContextWithMemory(
       leadSuit,
       memory,
     );
+  } else {
+    memoryContext.nextPlayerVoidLed = false; // No lead card or next player
   }
 
   return {

--- a/src/ai/following/multiComboFollowingStrategy.ts
+++ b/src/ai/following/multiComboFollowingStrategy.ts
@@ -400,10 +400,11 @@ function makeStrategicTrumpDecision(
     isTrump(card, trumpInfo),
   );
 
-  // Early return: Don't trump if teammate is winning
+  // Early return: Don't trump if teammate is winning, next opponent not void and we have yet full-trump
   if (
     context.trickWinnerAnalysis?.isTeammateWinning &&
-    !context.memoryContext?.nextPlayerVoidLed
+    !context.memoryContext?.nextPlayerVoidLed &&
+    playerHand.some((card) => !isTrump(card, trumpInfo))
   ) {
     return selectCrossSuitDisposal(
       leadingCards,
@@ -463,7 +464,7 @@ function makeStrategicTrumpDecision(
       leadingCards,
       trumpInfo,
       true,
-      true,
+      context.memoryContext?.nextPlayerVoidLed ? false : true, // Conservation mode if next player not void led suit
     );
   }
 }

--- a/src/ai/leading/firstPlayerLeadingAnalysis.ts
+++ b/src/ai/leading/firstPlayerLeadingAnalysis.ts
@@ -1,3 +1,4 @@
+import { isTrump } from "../../game/cardValue";
 import {
   Combo,
   ComboType,
@@ -8,7 +9,6 @@ import {
   PointPressure,
   TrumpInfo,
 } from "../../types";
-import { isTrump } from "../../game/cardValue";
 import { getRankValue } from "../analysis/comboAnalysis";
 
 /**
@@ -108,7 +108,7 @@ export function selectOptimalLeadingComboForPhase(
       candidates = validCombos.filter(
         (combo) =>
           !combo.cards.some((card) => isTrump(card, trumpInfo)) &&
-          combo.cards.every((card) => (card.points || 0) === 0),
+          combo.cards.every((card) => card.points === 0),
       );
       break;
 
@@ -116,8 +116,12 @@ export function selectOptimalLeadingComboForPhase(
       // Prefer strong, point-collecting leads
       candidates = validCombos.filter(
         (combo) =>
-          combo.cards.some((card) => (card.points || 0) > 0) ||
-          combo.cards.some((card) => isTrump(card, trumpInfo)),
+          combo.cards.some(
+            (card) => !isTrump(card, trumpInfo) && card.points > 0,
+          ) ||
+          combo.cards.some(
+            (card) => isTrump(card, trumpInfo) && card.points === 0,
+          ),
       );
       break;
 
@@ -205,9 +209,9 @@ function calculateLeadingComboValue(
       break;
 
     case "aggressive":
-      // Bonus for point cards and strong combinations
+      // Bonus for non-trump point cards and strong combinations
       const points = combo.cards.reduce(
-        (sum, card) => sum + (card.points || 0),
+        (sum, card) => sum + (!isTrump(card, trumpInfo) ? card.points : 0),
         0,
       );
       value += points * 2;
@@ -228,7 +232,7 @@ function calculateLeadingComboValue(
       const totalValue = combo.cards.reduce(
         (sum, card) =>
           sum +
-          (card.points || 0) +
+          card.points +
           (isTrump(card, trumpInfo)
             ? 10
             : card.rank


### PR DESCRIPTION
Prevents AI from leading with single trump point cards in aggressive mode.

- Modified  to filter out single trump point cards in aggressive mode.
- Modified  to only apply point bonus to non-trump cards in aggressive mode.
- Adjusted  to align with the new aggressive strategy.
- Included other related changes in  and .