### PR TITLE
fix: Preserve original hand order in AI invalid move logging

### DIFF
--- a/src/game/playProcessing.ts
+++ b/src/game/playProcessing.ts
@@ -598,10 +598,7 @@ export function getAIMoveWithErrorHandling(state: GameState): {
         "ai_invalid_move_details",
         {
           playerId: currentPlayer.id,
-          playerHand: currentPlayer.hand
-            .slice()
-            .sort((a, b) => a.id.localeCompare(b.id))
-            .map((card) => card.getDisplayName()),
+          playerHand: currentPlayer.hand.map((card) => card.getDisplayName()),
           playerHandSize: currentPlayer.hand.length,
           aiMove: aiMove.map((card) => card.getDisplayName()),
           currentTrick: state.currentTrick


### PR DESCRIPTION
## Summary
Fix AI debugging issue where `ai_invalid_move_details` logging was sorting player hands, making investigation difficult.

## Problem
- `ai_invalid_move_details` logging sorted hands by card ID using `.slice().sort((a, b) => a.id.localeCompare(b.id))`
- This changed the card order from the original hand order when AI decision was made
- Made debugging AI decisions extremely difficult as logged hands didn't match decision context

## Solution
- ✅ Remove sorting from `playerHand` logging in `ai_invalid_move_details`
- ✅ Preserve original hand order that AI was working with
- ✅ Verified no other logging has the same issue

## Impact
- **Debugging**: AI investigation now shows actual hand order when decisions were made
- **No functional changes**: Only affects logging output for debugging
- **Maintains consistency**: `handBefore` logging already preserved original order correctly

## Test Plan
- [x] All quality checks pass (887/887 tests)
- [x] Verified no other hand logging patterns have sorting issues
- [x] Zero lint/typecheck errors

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>