### PR TITLE
refactor(ai): Tweak multi-combo AI logic

### DIFF
--- a/src/ai/following/multiComboFollowingStrategy.ts
+++ b/src/ai/following/multiComboFollowingStrategy.ts
@@ -450,23 +450,24 @@ function makeStrategicTrumpDecision(
         };
       }
     }
-    // Cannot beat existing trump, use cross-suit disposal
-    return selectCrossSuitDisposal(
-      leadingCards,
-      playerHand,
-      trumpInfo,
-      context,
-    );
   } else {
     // Opponent is winning with non-trump - trump to beat them with conservation
-    return playMatchingMultiCombo(
+    const matchingResult = playMatchingMultiCombo(
       trumpCards,
       leadingCards,
       trumpInfo,
       true,
       context.memoryContext?.nextPlayerVoidLed ? false : true, // Conservation mode if next player not void led suit
     );
+
+    if (matchingResult.canBeat) {
+      // Can beat existing non-trump with trump
+      return matchingResult;
+    }
   }
+
+  // Cannot beat existing trump, use cross-suit disposal
+  return selectCrossSuitDisposal(leadingCards, playerHand, trumpInfo, context);
 }
 
 /**

--- a/src/ai/leading/multiComboLeadingStrategy.ts
+++ b/src/ai/leading/multiComboLeadingStrategy.ts
@@ -1,13 +1,12 @@
-import { identifyCombos } from "../../game/comboDetection";
 import { isTrump } from "../../game/cardValue";
+import { identifyCombos } from "../../game/comboDetection";
 import { analyzeComboStructure } from "../../game/multiComboAnalysis";
 import {
   checkOpponentVoidStatus,
   isComboUnbeatable,
 } from "../../game/multiComboValidation";
-import { Card, GameState, PlayerId, PointPressure, Suit } from "../../types";
+import { Card, GameState, PlayerId, Suit } from "../../types";
 import { createCardMemory } from "../aiCardMemory";
-import { createGameContext } from "../aiGameContext";
 
 /**
  * Multi-Combo Leading Strategy for AI
@@ -69,14 +68,15 @@ export function selectAIMultiComboLead(
         return mostUnbeatableCards;
       }
 
+      // Note: Let's not return weak multi-combos (only singles) unless we have no other options
       // If we have a weak multi-combo (only small singles), decide based on game context
-      const context = createGameContext(gameState, playerId);
-      if (
-        context.isAttackingTeam ||
-        context.pointPressure === PointPressure.LOW
-      ) {
-        return mostUnbeatableCards;
-      }
+      // const context = createGameContext(gameState, playerId);
+      // if (
+      //   context.isAttackingTeam ||
+      //   context.pointPressure === PointPressure.LOW
+      // ) {
+      //   return mostUnbeatableCards;
+      // }
     }
   }
 


### PR DESCRIPTION
Refactor the multi-combo following strategy to ensure the AI attempts to win with trump before resorting to cross-suit disposal. Simplify the leading strategy to prevent the AI from leading with weak multi-combos of only single cards.