### PR TITLE
Fix: Final trick scoring race condition

### DIFF
--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -362,16 +362,9 @@ export function useGameState() {
         (p) => p.hand.length === 0,
       );
       if (allCardsPlayed) {
-        // Set game phase to 'roundEnd' to prevent AI moves
-        const endingState = {
-          ...result.newState,
-          gamePhase: GamePhase.RoundEnd,
-        };
-        setGameState(endingState);
-
         // Add delay to ensure trick result displays before round complete modal
         setTimeout(() => {
-          handleEndRound(gameState);
+          handleEndRound(result.newState);
         }, TRICK_RESULT_DISPLAY_TIME + ROUND_COMPLETE_BUFFER);
       }
     } else {
@@ -390,7 +383,7 @@ export function useGameState() {
     setShowRoundComplete(true);
     // Store the round result and current state for processing after modal dismissal
     roundResultRef.current = roundResult;
-    pendingStateRef.current = JSON.parse(JSON.stringify(state)) as GameState; // Store current state, not modified state
+    pendingStateRef.current = JSON.parse(JSON.stringify(state)) as GameState; // Deepcopy current state, for next round preparation
 
     if (roundResult.gameOver) {
       // Set game phase to 'gameOver' to prevent AI moves
@@ -398,6 +391,9 @@ export function useGameState() {
       setGameState(gameOverState);
       setGameOver(true);
       setWinner(roundResult.gameWinner || null);
+    } else {
+      const endingState = { ...state, gamePhase: GamePhase.RoundEnd };
+      setGameState(endingState);
     }
   };
 


### PR DESCRIPTION
## Summary
- Fix race condition where final trick points weren't included in round results
- Simplify round end state flow and eliminate unnecessary state transitions
- Ensure attacking team receives proper final score including last trick points and kitty bonus

## Problem
When the attacking team won the final trick, the `setTimeout` callback was using stale `gameState` from before the final trick was processed, causing the round end calculation to miss:
- Points from the final trick itself
- Kitty bonus information stored in `roundEndKittyInfo`

## Solution
Use `result.newState` in the `setTimeout` callback, which contains the complete state after final trick processing including all points and kitty bonus data.

## Test plan
- [x] Verify final trick points are included when attacking team wins last trick
- [x] Verify kitty bonus calculation works correctly with new state flow
- [x] Check that no regressions in team role switching between rounds
- [x] Ensure empty player hands are properly handled in round transitions

🤖 Generated with [Claude Code](https://claude.ai/code)