### PR TITLE
Fix round complete modal timing in useGameState hook

### DIFF
--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -417,6 +417,8 @@ export function useGameState() {
     roundResultRef.current = roundResult;
     pendingStateRef.current = JSON.parse(JSON.stringify(state)) as GameState; // Deepcopy current state, for next round preparation
 
+    setShowRoundComplete(true);
+
     if (roundResult.gameOver) {
       // Set game phase to 'gameOver' to prevent AI moves (after storing state)
       const gameOverState = { ...state, gamePhase: GamePhase.GameOver };
@@ -425,9 +427,6 @@ export function useGameState() {
       setGameState(gameOverState);
     }
     // Note: For non-game-over, state already has GamePhase.RoundEnd set
-
-    // Show modal after all state is safely stored
-    setShowRoundComplete(true);
   };
 
   // Handle proceeding to next round


### PR DESCRIPTION
## Summary

Fix timing issue where the round complete modal might not display properly during game over scenarios by moving the modal trigger before state changes.

### Problem
- `setShowRoundComplete(true)` was called after potential game over state changes
- This could cause race conditions where the modal might not display during game over
- Inconsistent UI behavior between continuing and game over scenarios

### Solution
- Move `setShowRoundComplete(true)` to execute before any game over state changes
- Ensures modal always appears regardless of game continuation status
- Maintains proper UI flow and user experience

### Changes Made
- Moved `setShowRoundComplete(true)` earlier in the `handleRoundEnd` function
- Removed the delayed modal trigger after state storage
- Simplified control flow for better reliability

### Benefits
- **Consistent UI**: Modal appears reliably in all scenarios
- **Better UX**: Users always see round results before game transitions
- **Cleaner Code**: Simplified timing logic reduces complexity
- **Bug Prevention**: Eliminates potential race condition

## Test Plan
- [x] Round complete modal displays correctly for continuing games
- [x] Round complete modal displays correctly for game over scenarios  
- [x] No timing issues or UI glitches observed
- [x] All existing functionality preserved

🤖 Generated with [Claude Code](https://claude.ai/code)