### PR TITLE
Fix tractor formation logic: simplify context grouping, remove getTractorContext, update advanced tractor rules tests

### DIFF
--- a/__tests__/game/advancedTractorRules.test.ts
+++ b/__tests__/game/advancedTractorRules.test.ts
@@ -1,8 +1,6 @@
 import {
   findAllTractors,
-  getTractorContext,
   getTractorRank,
-  getTractorTypeDescription,
   isValidTractor,
 } from "../../src/game/tractorLogic";
 import {
@@ -120,37 +118,6 @@ describe("Advanced Tractor Rules - Unified Tractor Rank System", () => {
     });
   });
 
-  describe("Tractor Context Grouping", () => {
-    const trumpInfo: TrumpInfo = {
-      trumpSuit: Suit.Spades,
-      trumpRank: Rank.Seven,
-    };
-
-    test("should group jokers in joker context", () => {
-      const bigJoker = Card.createJoker(JokerType.Big, 0);
-      const smallJoker = Card.createJoker(JokerType.Small, 0);
-
-      expect(getTractorContext(bigJoker, trumpInfo)).toBe("joker");
-      expect(getTractorContext(smallJoker, trumpInfo)).toBe("joker");
-    });
-
-    test("should group trump rank cards in trump_rank context", () => {
-      const trumpSuitRank = Card.createCard(Suit.Spades, Rank.Seven, 0);
-      const offSuitRank = Card.createCard(Suit.Hearts, Rank.Seven, 0);
-
-      expect(getTractorContext(trumpSuitRank, trumpInfo)).toBe("trump_rank");
-      expect(getTractorContext(offSuitRank, trumpInfo)).toBe("trump_rank");
-    });
-
-    test("should group regular cards by suit", () => {
-      const heartCard = Card.createCard(Suit.Hearts, Rank.Six, 0);
-      const spadeCard = Card.createCard(Suit.Spades, Rank.Eight, 0);
-
-      expect(getTractorContext(heartCard, trumpInfo)).toBe(Suit.Hearts);
-      expect(getTractorContext(spadeCard, trumpInfo)).toBe(Suit.Spades);
-    });
-  });
-
   describe("Trump Cross-Suit Tractors", () => {
     test("should form tractor with trump suit rank pair + off-suit rank pair", () => {
       const trumpInfo: TrumpInfo = {
@@ -169,9 +136,6 @@ describe("Advanced Tractor Rules - Unified Tractor Rank System", () => {
       expect(tractors).toHaveLength(1);
       expect(tractors[0].type).toBe(ComboType.Tractor);
       expect(tractors[0].cards).toHaveLength(4);
-
-      const description = getTractorTypeDescription(cards, trumpInfo);
-      expect(description).toBe("Trump cross-suit tractor");
     });
 
     test("should NOT form tractor with only off-suit rank pairs", () => {
@@ -247,9 +211,6 @@ describe("Advanced Tractor Rules - Unified Tractor Rank System", () => {
       expect(tractors[0].cards).toHaveLength(4);
 
       expect(isValidTractor(cards, trumpInfo)).toBe(true);
-
-      const description = getTractorTypeDescription(cards, trumpInfo);
-      expect(description).toBe("Regular same-suit tractor"); // Appears regular due to bridging
     });
 
     test("should form multi-pair rank-skip tractor", () => {
@@ -348,14 +309,11 @@ describe("Advanced Tractor Rules - Unified Tractor Rank System", () => {
       expect(tractors[0].cards).toHaveLength(4);
 
       expect(isValidTractor(cards, trumpInfo)).toBe(true);
-
-      const description = getTractorTypeDescription(cards, trumpInfo);
-      expect(description).toBe("Joker tractor");
     });
   });
 
   describe("Invalid Tractor Combinations", () => {
-    test("should NOT form tractor with trump rank + joker pairs", () => {
+    test("should form tractor with trump rank + joker pairs", () => {
       const trumpInfo: TrumpInfo = {
         trumpSuit: Suit.Spades,
         trumpRank: Rank.Two,
@@ -369,9 +327,9 @@ describe("Advanced Tractor Rules - Unified Tractor Rank System", () => {
       ];
 
       const tractors = findAllTractors(cards, trumpInfo);
-      expect(tractors).toHaveLength(0); // Different contexts, different tractor ranks
+      expect(tractors).toHaveLength(1);
 
-      expect(isValidTractor(cards, trumpInfo)).toBe(false);
+      expect(isValidTractor(cards, trumpInfo)).toBe(true);
     });
 
     test("should NOT form tractor with non-trump cross-suit pairs", () => {

--- a/__tests__/game/comboTypes.test.ts
+++ b/__tests__/game/comboTypes.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "@jest/globals";
 import { compareCards } from "../../src/game/cardComparison";
-import { getComboType, identifyCombos } from "../../src/game/comboDetection";
 import { isTrump } from "../../src/game/cardValue";
+import { getComboType, identifyCombos } from "../../src/game/comboDetection";
 import {
   Card,
   ComboType,
@@ -363,7 +363,7 @@ describe("Combo Type Identification Tests", () => {
       expect(pairCombos.length).toBeGreaterThan(0);
     });
 
-    test("Joker combinations with trump cards should not form tractors", () => {
+    test("Joker combinations with trump cards should form tractors", () => {
       // Create a mix of jokers and trump cards
       const smallJokerPair = Card.createJokerPair(JokerType.Small);
       const spade2pair = Card.createPair(Suit.Spades, Rank.Two);
@@ -375,14 +375,14 @@ describe("Combo Type Identification Tests", () => {
       expect(isTrump(spade2pair[0], trumpInfo)).toBe(true);
 
       // They should not form a tractor
-      expect(getComboType(hand, trumpInfo)).not.toBe(ComboType.Tractor);
+      expect(getComboType(hand, trumpInfo)).toBe(ComboType.Tractor);
 
-      // When we run identifyCombos, it should not find a tractor
+      // When we run identifyCombos, it should find a tractor
       const combos = identifyCombos(hand, trumpInfo);
       const tractorCombos = combos.filter(
         (combo) => combo.type === ComboType.Tractor,
       );
-      expect(tractorCombos.length).toBe(0);
+      expect(tractorCombos.length).toBe(1);
     });
 
     test("A-A-2-2 combination with 2 as trump rank should not form a tractor", () => {


### PR DESCRIPTION
This PR simplifies the tractor formation logic by removing getTractorContext and grouping trump cards together for tractor detection. It also updates the advanced tractor rules tests to match the new logic. All quality checks pass.