### PR TITLE
Fix EAS workflow platform configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ A React Native implementation of the classic Chinese card game **Tractor** (also
 
 **Built with React Native + Expo** for cross-platform mobile development:
 
-- **React Native 0.76+** - Cross-platform mobile framework
-- **Expo SDK 52** - Development tools and native API access
-- **TypeScript 5.7+** - Strict type safety and enhanced developer experience
+- **React Native 0.81+** - Cross-platform mobile framework
+- **Expo SDK 54** - Development tools and native API access
+- **TypeScript 5.9+** - Strict type safety and enhanced developer experience
 - **React i18next** - Type-safe internationalization with automatic language detection
 - **Jest** - Comprehensive tests with React Testing Library
 - **ESLint** - Code quality with React Native specific rules

--- a/app.json
+++ b/app.json
@@ -58,6 +58,7 @@
       }
     },
     "owner": "ericvan76",
-    "runtimeVersion": "v1.0.0"
+    "runtimeVersion": "v1.0.0",
+    "platforms": ["ios", "android"]
   }
 }


### PR DESCRIPTION
## Summary
- Fix EAS update workflow failing due to web platform configuration
- Update documentation version numbers for Expo SDK 54 upgrade

## Changes
- Add explicit `platforms: ["ios", "android"]` to app.json to exclude web support
- Update README.md with correct version numbers (React Native 0.81+, Expo SDK 54, TypeScript 5.9+)

## Test plan
- [ ] Verify EAS update workflow runs successfully
- [ ] Confirm no web platform build attempts

Fixes the workflow error: "It looks like you're trying to use web support but don't have the required dependencies installed."

🤖 Generated with [Claude Code](https://claude.ai/code)