### PR TITLE
fix(ui): set player name border width to 1 for consistency

### DIFF
--- a/src/styles/sharedStyles.ts
+++ b/src/styles/sharedStyles.ts
@@ -9,7 +9,7 @@ export const sharedStyles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 14,
-    borderWidth: 0.5,
+    borderWidth: 1,
     shadowColor: "#000",
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.1,


### PR DESCRIPTION
## Summary
- Increase player name label borderWidth from 0.5 to 1
- Aligns with play button and GameStatus borders for consistent UI

## Rationale
- 0.5px appeared too light on some displays; 1px provides clearer contrast without visual noise

## Scope
- src/styles/sharedStyles.ts only; no runtime logic changes

## Test Plan
- Build and run the app
- Observe player name pill border thickness matches play button and GameStatus elements

🤖 Generated with [Claude Code](https://claude.ai/code)