### PR TITLE
feat: add human loss detection to game over modal with gray theme

### DIFF
--- a/src/locales/en/modals.json
+++ b/src/locales/en/modals.json
@@ -22,7 +22,13 @@
     "kittyBonus": "Kitty Bonus: {{kittyPoints}} x {{multiplier}}"
   },
   "gameOver": {
-    "title": "Victory!",
-    "newGame": "NEW GAME"
+    "win": {
+      "title": "Victory!",
+      "newGame": "NEW GAME"
+    },
+    "loss": {
+      "title": "Lost!",
+      "newGame": "NEW GAME"
+    }
   }
 }

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -111,8 +111,14 @@ export interface ModalsTranslations {
     kittyBonus: string;
   };
   gameOver: {
-    title: string;
-    newGame: string;
+    win: {
+      title: string;
+      newGame: string;
+    };
+    loss: {
+      title: string;
+      newGame: string;
+    };
   };
 }
 

--- a/src/locales/zh/modals.json
+++ b/src/locales/zh/modals.json
@@ -22,7 +22,13 @@
     "kittyBonus": "底牌分：{{kittyPoints}} x {{multiplier}}"
   },
   "gameOver": {
-    "title": "胜利!",
-    "newGame": "新游戏"
+    "win": {
+      "title": "胜利!",
+      "newGame": "新游戏"
+    },
+    "loss": {
+      "title": "输了!",
+      "newGame": "新游戏"
+    }
   }
 }

--- a/src/screens/GameScreenView.tsx
+++ b/src/screens/GameScreenView.tsx
@@ -314,6 +314,7 @@ const GameScreenView: React.FC<GameScreenViewProps> = ({
           fadeAnim={fadeAnim}
           scaleAnim={scaleAnim}
           kittyCards={sortCards(gameState.kittyCards, gameState.trumpInfo)}
+          humanTeamId={humanPlayer.team}
         />
       )}
     </View>


### PR DESCRIPTION
Implements conditional loss modal for human team defeat.

Changes:
- Gray theme for loss (no celebrations, skull icon)
- Win keeps gold theme and animations
- humanTeamId prop and updated translations/types

Tested with mock roundResultRef.current for quick verification. Ready for review.