### PR TITLE
docs: cleanup broken links and add versioning doc reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ This file provides guidance to coding agents when working with this repository.
 - [docs/GAME_RULES.md](docs/GAME_RULES.md) - Complete game rules and strategy
 - [docs/MULTI_COMBO.md](docs/MULTI_COMBO.md) - Multi-combo implementation guide
 - [docs/LOG_EVENT_SCHEMA.md](docs/LOG_EVENT_SCHEMA.md) - Log event structure
+- [docs/VERSIONING_STRATEGY.md](docs/VERSIONING_STRATEGY.md) - Versioning strategy and OTA compatibility
 
 ## Setup Commands
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ A React Native implementation of the classic Chinese card game **Tractor** (also
 - **[Game Rules](docs/GAME_RULES.md)** - Complete rules, quick start, and strategy reference
 - **[AI System](docs/AI_SYSTEM.md)** - Comprehensive AI intelligence documentation
 - **[AGENTS.md](AGENTS.md)** - Agent development guidelines and project architecture
-- **[GEMINI.md](GEMINI.md)** - Gemini development guidelines and project architecture
 
 ## Built with AI
 


### PR DESCRIPTION
Removes a broken link to GEMINI.md in README.md and adds a link to docs/VERSIONING_STRATEGY.md in AGENTS.md.