### PR TITLE
Fix: Update language indicator to show target language

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -26,6 +26,6 @@
     "spades": "Spades"
   },
   "language": {
-    "shortCode": "Eng"
+    "shortCode": "中文"
   }
 }

--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -26,6 +26,6 @@
     "spades": "黑桃"
   },
   "language": {
-    "shortCode": "中文"
+    "shortCode": "Eng"
   }
 }


### PR DESCRIPTION
Swapped the language short codes in translation files so that the indicator shows the target language (e.g., shows '中文' when in English). This helps non-English speakers find the language switcher.