### PR TITLE
fix: use commit count for beta runtimeVersion

### DIFF
--- a/.github/actions/git-version/action.yml
+++ b/.github/actions/git-version/action.yml
@@ -77,7 +77,7 @@ runs:
           BASE_VERSION="${MAJOR}.$((MINOR + 1)).0"
           VERSION="v${BASE_VERSION}-beta.${COMMIT_COUNT}"
           FULL_VERSION="v${BASE_VERSION}-beta.${COMMIT_COUNT}+${GIT_HASH_SHORT}"
-          RUNTIME_VERSION="v${BASE_VERSION}-beta"
+          RUNTIME_VERSION="v${BASE_VERSION}-beta.${COMMIT_COUNT}"
           EAS_BRANCH="preview"
           
         else

--- a/docs/VERSIONING_STRATEGY.md
+++ b/docs/VERSIONING_STRATEGY.md
@@ -36,7 +36,7 @@ Tractor uses a triple-version system with explicit runtime version control for p
 
 ### Beta Builds (Main Branch)
 - **App Version**: `v1.1.0-beta.5` (clean version)
-- **Runtime Version**: `v1.1.0-beta.5+def5678` (isolated)
+- **Runtime Version**: `v1.1.0-beta.5` (isolated by commit count)
 - **Full Version**: `v1.1.0-beta.5+def5678` (complete tracking)
 - **OTA**: Isolated per build
 


### PR DESCRIPTION
## Summary\n\nUpdates the `git-version` GitHub Action to include the commit count in the `runtimeVersion` for preview (beta) builds (e.g. `v1.3.0-beta.11`).\n\nThis isolates each beta build to its own runtime version, preventing Expo Go compatibility errors and ensuring native mismatches across different beta commits are properly gated.