### PR TITLE
chore: upgrade GitHub actions to run on Node 24

### DIFF
--- a/.github/workflows/eas-build-apk.yml
+++ b/.github/workflows/eas-build-apk.yml
@@ -14,13 +14,13 @@ jobs:
     
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ github.event.release.tag_name || github.sha }}
         fetch-depth: 0
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '24'
         cache: 'npm'

--- a/.github/workflows/eas-update.yml
+++ b/.github/workflows/eas-update.yml
@@ -23,12 +23,12 @@ jobs:
     
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '24'
         cache: 'npm'
@@ -51,7 +51,7 @@ jobs:
       run: TARGET_GAMES=3 npm run test:simulation
 
     - name: Archive simulation logs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: failure() # Only upload logs when tests fail
       with:
         name: simulation-logs-${{ github.run_number }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -16,10 +16,10 @@ jobs:
     
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '24'
         cache: 'npm'
@@ -34,7 +34,7 @@ jobs:
       run: TARGET_GAMES=3 npm run test:simulation
 
     - name: Archive simulation logs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: failure() # Only upload logs when tests fail
       with:
         name: pr-simulation-logs-${{ github.event.number }}


### PR DESCRIPTION
Updates GitHub Actions to their latest major versions to run on Node 24, as Node 20 is reaching end-of-life on GitHub Action runners.