### PR TITLE
Fix React Compiler translation bug & update CI EAS flags

### DIFF
--- a/.github/workflows/eas-build-apk.yml
+++ b/.github/workflows/eas-build-apk.yml
@@ -44,16 +44,20 @@ jobs:
 
     - name: Build APK
       if: steps.version.outputs.eas-branch == 'production' || steps.version.outputs.eas-branch == 'preview'
-      run: eas build --platform android --profile ${{ steps.version.outputs.eas-branch }} --non-interactive --wait
+      run: eas build --platform android --profile ${{ steps.version.outputs.eas-branch }} --wait
+      env:
+        CI: 1
 
     - name: Get build artifact URL
       if: steps.version.outputs.eas-branch == 'production' || steps.version.outputs.eas-branch == 'preview'
       id: build-url
       run: |
         # Get the latest build for this project
-        BUILD_URL=$(eas build:list --platform android --limit 1 --json --non-interactive | jq -r '.[0].artifacts.buildUrl')
+        BUILD_URL=$(eas build:list --platform android --limit 1 --json | jq -r '.[0].artifacts.buildUrl')
         echo "build_url=$BUILD_URL" >> $GITHUB_OUTPUT
         echo "Build URL: $BUILD_URL"
+      env:
+        CI: 1
 
     - name: Download APK
       if: github.event_name == 'release'

--- a/.github/workflows/eas-update.yml
+++ b/.github/workflows/eas-update.yml
@@ -81,6 +81,7 @@ jobs:
       uses: ./.github/actions/git-version
 
     - name: EAS Update
-      run: eas update --branch ${{ steps.version.outputs.eas-branch }} --environment ${{ steps.version.outputs.eas-branch }} --message "Update ${{ steps.version.outputs.full-version }}" --non-interactive
+      run: eas update --branch ${{ steps.version.outputs.eas-branch }} --environment ${{ steps.version.outputs.eas-branch }} --message "Update ${{ steps.version.outputs.full-version }}"
       env:
         EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        CI: 1


### PR DESCRIPTION
This PR addresses two maintenance updates:

1. **React Compiler Translation Bugfix**: 
- Fixes an issue where player names, teams, and suits would not update dynamically on language switch due to the React Compiler memoizing components relying on a global `i18n.t` un-tracked by hooks.
- Refactors translation helpers (`translationHelpers.ts`) to require the component's reactive `t` function.
- Updates `HumanPlayerView`, `AIPlayerView`, `TrickResultDisplay`, `GameStatus`, etc., to pass localized `tCommon` hooks.
- Includes full unit test coverage for the helpers.

2. **EAS Workflow Updates**:
- Replaces deprecated `--non-interactive` flags across all `eas update` and `eas build` steps in GitHub Actions workflows with standard `CI: 1` environment variables to ensure headless execution continues working correctly.