### PR TITLE
Migrate to Expo Development Build

### DIFF
--- a/.github/workflows/eas-build-dev.yml
+++ b/.github/workflows/eas-build-dev.yml
@@ -1,0 +1,53 @@
+name: EAS Build Dev Client
+
+on: 
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build Dev Client APK
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: '24'
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Setup Expo
+      uses: expo/expo-github-action@v8
+      with:
+        eas-version: latest
+        packager: npm
+        token: ${{ secrets.EXPO_TOKEN }}
+
+    - name: Detect version and inject into app.json
+      id: version
+      uses: ./.github/actions/git-version
+
+    - name: Build Dev Client APK
+      run: eas build --platform android --profile development --wait
+      env:
+        CI: 1
+
+    - name: Get build artifact URL
+      id: build-url
+      run: |
+        # Get the latest build for this project
+        BUILD_URL=$(eas build:list --platform android --limit 1 --json | jq -r '.[0].artifacts.buildUrl')
+        echo "build_url=$BUILD_URL" >> $GITHUB_OUTPUT
+        echo "Build URL: $BUILD_URL"
+      env:
+        CI: 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@react-navigation/native": "^7.1.6",
         "eslint-config-expo": "~55.0.0",
         "expo": "~55.0.0",
+        "expo-dev-client": "~55.0.18",
         "expo-font": "~55.0.4",
         "expo-linking": "~55.0.8",
         "expo-localization": "~55.0.9",
@@ -7314,6 +7315,57 @@
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-dev-client": {
+      "version": "55.0.18",
+      "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-55.0.18.tgz",
+      "integrity": "sha512-zQeCGk+doTMIKwPe9lNlGcUiBlMpJQNyrrsYc5eRdxuMwBrDVAU7zshARmamSw8zlAIHCsThJH2zeJg/lgQrKA==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-launcher": "55.0.19",
+        "expo-dev-menu": "55.0.16",
+        "expo-dev-menu-interface": "55.0.1",
+        "expo-manifests": "~55.0.11",
+        "expo-updates-interface": "~55.1.3"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-launcher": {
+      "version": "55.0.19",
+      "resolved": "https://registry.npmjs.org/expo-dev-launcher/-/expo-dev-launcher-55.0.19.tgz",
+      "integrity": "sha512-RtiC/K7Cg7RafNlq32GtilMEO5cy61HPBKASQHwLK6Gz5+FYepx0KSHIXIhWqekZMfpcj1w80tvEjMNFjUJ9Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/schema-utils": "^55.0.2",
+        "expo-dev-menu": "55.0.16",
+        "expo-manifests": "~55.0.11"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-menu": {
+      "version": "55.0.16",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu/-/expo-dev-menu-55.0.16.tgz",
+      "integrity": "sha512-UhduIh/6wQmFLIy1EeQJBCN09irOrC1kf/UMQ9CxXCkXit9SOtJx+26YfCmbrIRV/lYK2qZK8Y178/HNkt7yeA==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-menu-interface": "55.0.1"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-menu-interface": {
+      "version": "55.0.1",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu-interface/-/expo-dev-menu-interface-55.0.1.tgz",
+      "integrity": "sha512-FkNtwq1q6NmYoy28pj+ZLuHmirJgc039pQbJ167MZJIaprLcMN1yy67qA7xBHK+FNJ8AN8kGCtMTPByg5UC72A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-eas-client": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "main": "expo-router/entry",
   "version": "1.0.0",
   "scripts": {
+    "start:dev": "node scripts/inject-dev-version.js && expo start --dev-client",
     "start": "node scripts/inject-dev-version.js && expo start",
     "android": "node scripts/inject-dev-version.js && expo start --android",
     "ios": "node scripts/inject-dev-version.js && expo start --ios",
@@ -26,6 +27,7 @@
     "@react-navigation/native": "^7.1.6",
     "eslint-config-expo": "~55.0.0",
     "expo": "~55.0.0",
+    "expo-dev-client": "~55.0.18",
     "expo-font": "~55.0.4",
     "expo-linking": "~55.0.8",
     "expo-localization": "~55.0.9",


### PR DESCRIPTION
Adds `expo-dev-client`, updates `package.json` with `start:dev`, and adds a manual `eas-build-dev.yml` workflow to allow generating the custom development APK from GitHub Actions.