### PR TITLE
Fix: Install missing expo-constants peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@react-navigation/native": "^7.1.6",
         "eslint-config-expo": "~55.0.0",
         "expo": "~55.0.0",
+        "expo-constants": "~55.0.9",
         "expo-dev-client": "~55.0.18",
         "expo-font": "~55.0.4",
         "expo-linking": "~55.0.8",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@react-navigation/native": "^7.1.6",
     "eslint-config-expo": "~55.0.0",
     "expo": "~55.0.0",
+    "expo-constants": "~55.0.9",
     "expo-dev-client": "~55.0.18",
     "expo-font": "~55.0.4",
     "expo-linking": "~55.0.8",


### PR DESCRIPTION
Required by expo-router to pass expo doctor checks in a Development Build.