### PR TITLE
Fix: Make EAS build URL extraction robust

### DIFF
--- a/.github/workflows/eas-build-apk.yml
+++ b/.github/workflows/eas-build-apk.yml
@@ -52,8 +52,8 @@ jobs:
       if: steps.version.outputs.eas-branch == 'production' || steps.version.outputs.eas-branch == 'preview'
       id: build-url
       run: |
-        # Get the latest build for this project
-        BUILD_URL=$(eas build:list --platform android --limit 1 --json | jq -r '.[0].artifacts.buildUrl')
+        # Get the latest SUCCESSFUL build for this project
+        BUILD_URL=$(eas build:list --platform android --profile ${{ steps.version.outputs.eas-branch }} --status finished --limit 1 --json | jq -r '.[0].artifacts | .buildUrl // .applicationArchiveUrl // empty')
         echo "build_url=$BUILD_URL" >> $GITHUB_OUTPUT
         echo "Build URL: $BUILD_URL"
       env:

--- a/.github/workflows/eas-build-dev.yml
+++ b/.github/workflows/eas-build-dev.yml
@@ -45,8 +45,8 @@ jobs:
     - name: Get build artifact URL
       id: build-url
       run: |
-        # Get the latest build for this project
-        BUILD_URL=$(eas build:list --platform android --limit 1 --json | jq -r '.[0].artifacts.buildUrl')
+        # Get the latest SUCCESSFUL build for this project
+        BUILD_URL=$(eas build:list --platform android --profile development --status finished --limit 1 --json | jq -r '.[0].artifacts | .buildUrl // .applicationArchiveUrl // empty')
         echo "build_url=$BUILD_URL" >> $GITHUB_OUTPUT
         echo "Build URL: $BUILD_URL"
       env:


### PR DESCRIPTION
Filters for successful builds and extracts both APK and AAB URLs safely.