### PR TITLE
Fix: Ensure EAS CLI outputs clean JSON

### DIFF
--- a/.github/workflows/eas-build-apk.yml
+++ b/.github/workflows/eas-build-apk.yml
@@ -53,7 +53,7 @@ jobs:
       id: build-url
       run: |
         # Get the latest SUCCESSFUL build for this project
-        BUILD_URL=$(eas build:list --platform android --profile ${{ steps.version.outputs.eas-branch }} --status finished --limit 1 --json | jq -r '.[0].artifacts | .buildUrl // .applicationArchiveUrl // empty')
+        BUILD_URL=$(eas build:list --platform android --profile ${{ steps.version.outputs.eas-branch }} --status finished --limit 1 --json --non-interactive | jq -r '.[0].artifacts | .buildUrl // .applicationArchiveUrl // empty')
         echo "build_url=$BUILD_URL" >> $GITHUB_OUTPUT
         echo "Build URL: $BUILD_URL"
       env:

--- a/.github/workflows/eas-build-dev.yml
+++ b/.github/workflows/eas-build-dev.yml
@@ -46,7 +46,7 @@ jobs:
       id: build-url
       run: |
         # Get the latest SUCCESSFUL build for this project
-        BUILD_URL=$(eas build:list --platform android --profile development --status finished --limit 1 --json | jq -r '.[0].artifacts | .buildUrl // .applicationArchiveUrl // empty')
+        BUILD_URL=$(eas build:list --platform android --profile development --status finished --limit 1 --json --non-interactive | jq -r '.[0].artifacts | .buildUrl // .applicationArchiveUrl // empty')
         echo "build_url=$BUILD_URL" >> $GITHUB_OUTPUT
         echo "Build URL: $BUILD_URL"
       env:


### PR DESCRIPTION
Without `--non-interactive`, EAS CLI outputs update prompts or console artifacts to stdout, which completely breaks `jq` pipeline extraction. This enforces pure JSON output.