### PR TITLE
feat(ai): implement tractor preservation when following pairs

### DIFF
--- a/__tests__/ai/following/strategicSelection.test.ts
+++ b/__tests__/ai/following/strategicSelection.test.ts
@@ -1,5 +1,15 @@
-import { selectCardsByStrategicValue } from "../../../src/ai/following/strategicSelection";
-import { Card, Rank, Suit, TrumpInfo } from "../../../src/types";
+import {
+  selectCardsByStrategicValue,
+  selectComboByStrategicValue,
+} from "../../../src/ai/following/strategicSelection";
+import {
+  Card,
+  Combo,
+  ComboType,
+  Rank,
+  Suit,
+  TrumpInfo,
+} from "../../../src/types";
 
 describe("Strategic Selection - Pair Preservation", () => {
   const trumpInfo: TrumpInfo = {
@@ -130,6 +140,118 @@ describe("Strategic Selection - Pair Preservation", () => {
       expect(result).toHaveLength(1);
       // Should pick Queen (lowest unpaired card), preserve A♠A♠ pair
       expect(result[0].rank).toBe(Rank.Queen);
+    });
+  });
+
+  describe("selectComboByStrategicValue - Tractor Preservation", () => {
+    it("should preserve a tractor when selecting a pair (lowest direction)", () => {
+      // Hand has: K♠K♠, Q♠Q♠ (forms a tractor) and 9♠9♠ (standalone pair)
+      const kPair = Card.createPair(Suit.Spades, Rank.King);
+      const qPair = Card.createPair(Suit.Spades, Rank.Queen);
+      const ninePair = Card.createPair(Suit.Spades, Rank.Nine);
+
+      const hand = [...kPair, ...qPair, ...ninePair];
+
+      const validCombos: Combo[] = [
+        { type: ComboType.Pair, cards: kPair, value: 0 },
+        { type: ComboType.Pair, cards: qPair, value: 0 },
+        { type: ComboType.Pair, cards: ninePair, value: 0 },
+      ];
+
+      // Select 1 pair with "lowest" direction - should pick 9♠9♠ to preserve the K♠-Q♠ tractor
+      const result = selectComboByStrategicValue(
+        validCombos,
+        trumpInfo,
+        "basic",
+        "lowest",
+        1,
+        hand,
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result[0].rank).toBe(Rank.Nine);
+      expect(result[1].rank).toBe(Rank.Nine);
+    });
+
+    it("should preserve a tractor when selecting a pair (highest direction)", () => {
+      // Hand has: K♠K♠, Q♠Q♠ (forms a tractor) and 10♠10♠ (standalone pair)
+      const kPair = Card.createPair(Suit.Spades, Rank.King);
+      const qPair = Card.createPair(Suit.Spades, Rank.Queen);
+      const tenPair = Card.createPair(Suit.Spades, Rank.Ten);
+
+      const hand = [...kPair, ...qPair, ...tenPair];
+
+      const validCombos: Combo[] = [
+        { type: ComboType.Pair, cards: kPair, value: 0 },
+        { type: ComboType.Pair, cards: qPair, value: 0 },
+        { type: ComboType.Pair, cards: tenPair, value: 0 },
+      ];
+
+      // Select 1 pair with "highest" direction - should pick 10♠10♠ to preserve the K♠-Q♠ tractor
+      // (even though King and Queen are individually higher strategic value)
+      const result = selectComboByStrategicValue(
+        validCombos,
+        trumpInfo,
+        "basic",
+        "highest",
+        1,
+        hand,
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result[0].rank).toBe(Rank.Ten);
+      expect(result[1].rank).toBe(Rank.Ten);
+    });
+
+    it("should break a tractor if no other standalone pairs are available", () => {
+      // Hand has only the tractor: K♠K♠, Q♠Q♠
+      const kPair = Card.createPair(Suit.Spades, Rank.King);
+      const qPair = Card.createPair(Suit.Spades, Rank.Queen);
+
+      const hand = [...kPair, ...qPair];
+
+      const validCombos: Combo[] = [
+        { type: ComboType.Pair, cards: kPair, value: 0 },
+        { type: ComboType.Pair, cards: qPair, value: 0 },
+      ];
+
+      // Select 1 pair with "highest" direction - must break tractor, and should pick the higher pair (King)
+      const result = selectComboByStrategicValue(
+        validCombos,
+        trumpInfo,
+        "basic",
+        "highest",
+        1,
+        hand,
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result[0].rank).toBe(Rank.King);
+      expect(result[1].rank).toBe(Rank.King);
+    });
+
+    it("should be backward compatible and work without playerHand passed", () => {
+      // Hand has: K♠K♠, Q♠Q♠
+      const kPair = Card.createPair(Suit.Spades, Rank.King);
+      const qPair = Card.createPair(Suit.Spades, Rank.Queen);
+
+      const validCombos: Combo[] = [
+        { type: ComboType.Pair, cards: kPair, value: 0 },
+        { type: ComboType.Pair, cards: qPair, value: 0 },
+      ];
+
+      // Select 1 pair with "highest" direction without passing hand - should select King purely by strategic value
+      const result = selectComboByStrategicValue(
+        validCombos,
+        trumpInfo,
+        "basic",
+        "highest",
+        1,
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result[0].rank).toBe(Rank.King);
+      expect(result[1].rank).toBe(Rank.King);
     });
   });
 });

--- a/src/ai/following/sameSuitDecision.ts
+++ b/src/ai/following/sameSuitDecision.ts
@@ -60,6 +60,9 @@ export function handleEnoughRemainingScenario(
     currentPlayerId,
   );
 
+  const player = gameState.players.find((p) => p.id === currentPlayerId);
+  const playerHand = player ? player.hand : undefined;
+
   // Try to form best combo structure first
   const selectedCards = selectBestComboStructure(
     analysis.remainingCards,
@@ -67,6 +70,7 @@ export function handleEnoughRemainingScenario(
     analysis.requiredLength,
     trumpInfo,
     shouldContribute,
+    playerHand,
   );
 
   gameLogger.debug("following_enough_remaining_result", {
@@ -97,6 +101,7 @@ function selectBestComboStructure(
   requiredLength: number,
   trumpInfo: TrumpInfo,
   shouldContribute: boolean,
+  playerHand?: Card[],
 ): Card[] {
   // Calculate how many pairs we need based on leading combo type and length
   const requiredPairs = getRequiredPairs(leadingComboType, requiredLength);
@@ -115,6 +120,7 @@ function selectBestComboStructure(
         shouldContribute ? "contribute" : "strategic",
         "lowest",
         requiredPairs,
+        playerHand,
       );
 
       selectedCards.push(...bestPairCards);

--- a/src/ai/following/strategicSelection.ts
+++ b/src/ai/following/strategicSelection.ts
@@ -1,5 +1,6 @@
 import { calculateCardStrategicValue } from "../../game/cardValue";
-import { Card, Combo, TrumpInfo } from "../../types";
+import { Card, Combo, ComboType, TrumpInfo } from "../../types";
+import { findAllTractors } from "../../game/tractorLogic";
 
 /**
  * Strategic Selection Functions for Enhanced Following V2
@@ -11,6 +12,20 @@ import { Card, Combo, TrumpInfo } from "../../types";
 // =============== CORE SELECTION UTILITIES ===============
 
 /**
+ * Helper function to determine if a pair combo is part of a tractor in a set of tractors
+ */
+function isPairInTractor(pair: Combo, tractors: Combo[]): boolean {
+  if (pair.cards.length !== 2) return false;
+  const cardA = pair.cards[0];
+  const cardB = pair.cards[1];
+  return tractors.some(
+    (tractor) =>
+      tractor.cards.some((c) => c.id === cardA.id) &&
+      tractor.cards.some((c) => c.id === cardB.id),
+  );
+}
+
+/**
  * Core combo selection function - selects combo(s) based on strategic value
  *
  * @param validCombos - Array of combos to choose from
@@ -18,6 +33,7 @@ import { Card, Combo, TrumpInfo } from "../../types";
  * @param mode - Strategic value calculation mode
  * @param direction - Whether to select highest or lowest value
  * @param requiredComboLength - Number of combos to select (default 1)
+ * @param playerHand - Optional full player hand for tractor preservation
  * @returns Selected combo cards
  */
 export function selectComboByStrategicValue(
@@ -26,6 +42,7 @@ export function selectComboByStrategicValue(
   mode: "contribute" | "strategic" | "basic",
   direction: "highest" | "lowest",
   requiredComboLength: number = 1,
+  playerHand?: Card[],
 ): Card[] {
   if (validCombos.length === 0) {
     throw new Error("selectComboByStrategicValue called with no valid combos");
@@ -45,19 +62,31 @@ export function selectComboByStrategicValue(
   }
 
   // For non-single combos (pairs, tractors), use original combo-based selection
-  // TODO: Also preserve tractors when selecting pairs (similar to pair preservation logic)
-  const comboScores = validCombos.map((combo) => ({
-    combo,
-    score: combo.cards.reduce(
-      (sum, card) => sum + calculateCardStrategicValue(card, trumpInfo, mode),
-      0,
-    ),
-  }));
+  // TRACTOR PRESERVATION: If playerHand is provided, identify tractors to preserve them
+  const tractors = playerHand ? findAllTractors(playerHand, trumpInfo) : [];
 
-  // Sort by score based on direction
-  comboScores.sort((a, b) =>
-    direction === "highest" ? b.score - a.score : a.score - b.score,
-  );
+  const comboScores = validCombos.map((combo) => {
+    const isTractorPart =
+      combo.type === ComboType.Pair && isPairInTractor(combo, tractors);
+    return {
+      combo,
+      score: combo.cards.reduce(
+        (sum, card) => sum + calculateCardStrategicValue(card, trumpInfo, mode),
+        0,
+      ),
+      isTractorPart,
+    };
+  });
+
+  // Sort by score based on direction, while preserving tractors
+  comboScores.sort((a, b) => {
+    // First priority: prefer non-tractor-part combos (preserve tractors)
+    if (a.isTractorPart !== b.isTractorPart) {
+      return a.isTractorPart ? 1 : -1; // non-tractor-part comes first
+    }
+    // Second priority: sort by strategic value based on direction
+    return direction === "highest" ? b.score - a.score : a.score - b.score;
+  });
 
   // Select the required number of combos and return all their cards
   const selectedCombos = comboScores.slice(0, requiredComboLength);

--- a/src/ai/following/validCombosDecision.ts
+++ b/src/ai/following/validCombosDecision.ts
@@ -62,6 +62,10 @@ export function handleTrumpLeadValidCombos(
 
   const { isTeammateWinning, trickPoints } = trickAnalysis;
 
+  // Retrieve playerHand for tractor preservation
+  const player = gameState.players.find((p) => p.id === currentPlayerId);
+  const playerHand = player ? player.hand : undefined;
+
   gameLogger.debug("following_trump_lead_analysis", {
     player: currentPlayerId,
     validComboCount: analysis.validCombos.length,
@@ -87,6 +91,8 @@ export function handleTrumpLeadValidCombos(
       trumpInfo,
       "contribute",
       "lowest",
+      1,
+      playerHand,
     );
     if (contributionCards.length > 0) {
       gameLogger.debug("following_trump_contribute_teammate", {
@@ -105,6 +111,7 @@ export function handleTrumpLeadValidCombos(
     trumpInfo,
     gameState,
     currentPlayerId,
+    playerHand,
   );
 
   if (positionResult) {
@@ -130,6 +137,7 @@ export function handleTrumpLeadValidCombos(
     trumpInfo,
     trickPoints,
     isTeammateWinning,
+    playerHand,
   );
 
   if (beatResult) {
@@ -148,6 +156,8 @@ export function handleTrumpLeadValidCombos(
     trumpInfo,
     "strategic",
     "lowest",
+    1,
+    playerHand,
   );
 
   gameLogger.debug("following_trump_dispose", {
@@ -196,6 +206,10 @@ export function handleNonTrumpLeadValidCombos(
 
   const { isTeammateWinning, isCurrentlyTrumped } = trickAnalysis;
 
+  // Retrieve playerHand for tractor preservation
+  const player = gameState.players.find((p) => p.id === currentPlayerId);
+  const playerHand = player ? player.hand : undefined;
+
   gameLogger.debug("following_nontrump_lead_analysis", {
     player: currentPlayerId,
     validComboCount: analysis.validCombos.length,
@@ -221,6 +235,8 @@ export function handleNonTrumpLeadValidCombos(
       trumpInfo,
       "contribute",
       "lowest",
+      1,
+      playerHand,
     );
     if (contributionCards.length > 0) {
       gameLogger.debug("following_contribute_to_teammate", {
@@ -239,6 +255,8 @@ export function handleNonTrumpLeadValidCombos(
       trumpInfo,
       "basic",
       "highest",
+      1,
+      playerHand,
     );
 
     // Check if this combo can actually beat the current winner
@@ -265,6 +283,8 @@ export function handleNonTrumpLeadValidCombos(
     trumpInfo,
     "strategic",
     "lowest",
+    1,
+    playerHand,
   );
 
   gameLogger.debug("following_dispose_nontrump", {
@@ -288,6 +308,7 @@ function attemptToBeatWithThreshold(
   trumpInfo: TrumpInfo,
   trickPoints: number,
   isTeammateWinning: boolean,
+  playerHand?: Card[],
 ): Card[] | null {
   if (currentWinnerCards.length === 0) {
     return null; // Can't beat if no current winner
@@ -338,6 +359,8 @@ function attemptToBeatWithThreshold(
       trumpInfo,
       "contribute",
       "lowest",
+      1,
+      playerHand,
     );
   }
 
@@ -360,6 +383,7 @@ function applyPositionAwareTrumpStrategy(
   trumpInfo: TrumpInfo,
   gameState: GameState,
   currentPlayerId: PlayerId,
+  playerHand?: Card[],
 ): Card[] | null {
   const trickAnalysis = context.trickWinnerAnalysis;
   if (!trickAnalysis) return null;
@@ -389,6 +413,7 @@ function applyPositionAwareTrumpStrategy(
         currentWinnerStrength,
         isTeammateWinning,
         trumpInfo,
+        playerHand,
       );
 
     case TrickPosition.Third:
@@ -402,6 +427,7 @@ function applyPositionAwareTrumpStrategy(
         isTeammateWinning,
         trickPoints,
         trumpInfo,
+        playerHand,
       );
 
     case TrickPosition.Fourth:
@@ -410,6 +436,7 @@ function applyPositionAwareTrumpStrategy(
         currentWinnerCards,
         isTeammateWinning,
         trumpInfo,
+        playerHand,
       );
 
     default:
@@ -429,6 +456,7 @@ function handleSecondPlayerTrumpStrategy(
   currentWinnerStrength: number,
   isTeammateWinning: boolean,
   trumpInfo: TrumpInfo,
+  playerHand?: Card[],
 ): Card[] | null {
   // Only raise against weak leads; strong leads handled by generic beat logic
   if (currentWinnerStrength >= 110) return null;
@@ -448,6 +476,8 @@ function handleSecondPlayerTrumpStrategy(
     trumpInfo,
     "strategic",
     "lowest",
+    1,
+    playerHand,
   );
 
   // Don't raise if our cheapest beat is too expensive (value > 150, e.g. jokers)
@@ -481,6 +511,7 @@ function handleThirdPlayerTrumpStrategy(
   isTeammateWinning: boolean,
   trickPoints: number,
   trumpInfo: TrumpInfo,
+  playerHand?: Card[],
 ): Card[] | null {
   // Check if 4th player is an opponent
   const fourthPlayerIsOpponent = isFourthPlayerOpponent(
@@ -513,6 +544,8 @@ function handleThirdPlayerTrumpStrategy(
         trumpInfo,
         "strategic",
         "lowest",
+        1,
+        playerHand,
       );
 
       const raiseStrength = getMaxStrategicValue(cheapestStrongBeat, trumpInfo);
@@ -539,6 +572,8 @@ function handleThirdPlayerTrumpStrategy(
       trumpInfo,
       "strategic",
       "lowest",
+      1,
+      playerHand,
     );
 
     const finalBeatStrength = getMaxStrategicValue(cheapestBeat, trumpInfo);
@@ -568,6 +603,8 @@ function handleThirdPlayerTrumpStrategy(
       trumpInfo,
       "strategic",
       "lowest",
+      1,
+      playerHand,
     );
 
     const raiseStrength = getMaxStrategicValue(cheapestRaise, trumpInfo);
@@ -596,6 +633,7 @@ function handleFourthPlayerTrumpStrategy(
   currentWinnerCards: Card[],
   isTeammateWinning: boolean,
   trumpInfo: TrumpInfo,
+  playerHand?: Card[],
 ): Card[] | null {
   // When teammate is winning, don't overtake (handled by Step 2)
   if (isTeammateWinning) return null;
@@ -612,6 +650,8 @@ function handleFourthPlayerTrumpStrategy(
     trumpInfo,
     "strategic",
     "lowest",
+    1,
+    playerHand,
   );
 
   gameLogger.debug("following_trump_4th_optimal_beat", {

--- a/src/ai/following/voidDecision.ts
+++ b/src/ai/following/voidDecision.ts
@@ -37,6 +37,7 @@ function evaluateTrumpSelection(
   gameState: GameState,
   _currentPlayerId: PlayerId,
   analysis: SuitAvailabilityResult,
+  fullHand?: Card[],
 ): Card[] | null {
   const currentTrick = gameState.currentTrick;
   const isTeammateWinning =
@@ -91,6 +92,7 @@ function evaluateTrumpSelection(
           "contribute",
           "lowest",
           1,
+          fullHand,
         );
       }
 
@@ -122,6 +124,8 @@ function evaluateTrumpSelection(
             trumpInfo,
             "contribute",
             "lowest",
+            1,
+            fullHand,
           );
 
           const value = calculateCardStrategicValue(
@@ -151,6 +155,8 @@ function evaluateTrumpSelection(
           trumpInfo,
           "strategic",
           highValueCombos.length > 0 ? "lowest" : "highest",
+          1,
+          fullHand,
         );
       }
     }
@@ -222,6 +228,7 @@ export function handleVoidScenario(
       gameState,
       currentPlayerId,
       analysis,
+      playerHand,
     );
   }
 


### PR DESCRIPTION
This PR implements tractor-preservation logic for AI opponents when following pair plays, ensuring that stand-alone pairs are played first before breaking up consecutive tractors.