### PR TITLE
Add manual trigger to EAS Build APK workflow

### DIFF
--- a/.github/workflows/eas-build-apk.yml
+++ b/.github/workflows/eas-build-apk.yml
@@ -3,6 +3,7 @@ name: EAS Build APK
 on:
   release:
     types: [prereleased, released]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
This PR adds the 'workflow_dispatch' event to the EAS Build APK workflow, allowing it to be triggered manually from the GitHub Actions tab.