### PR TITLE
Optimize runtimeVersion for development and preview updates

### DIFF
--- a/.github/actions/git-version/action.yml
+++ b/.github/actions/git-version/action.yml
@@ -81,12 +81,12 @@ runs:
           EAS_BRANCH="preview"
           
         else
-          # Other branch (manual trigger) - isolate with stable alpha runtime version
+          # Other branch (manual trigger) - isolate with git hash in runtime version
           # Increment minor version by 1 and reset patch to 0
           BASE_VERSION="${MAJOR}.$((MINOR + 1)).0"
           VERSION="v${BASE_VERSION}-alpha.${COMMIT_COUNT}"
           FULL_VERSION="v${BASE_VERSION}-alpha.${COMMIT_COUNT}+${GIT_HASH_SHORT}"
-          RUNTIME_VERSION="v${BASE_VERSION}-alpha"
+          RUNTIME_VERSION="v${BASE_VERSION}-alpha.${COMMIT_COUNT}+${GIT_HASH_SHORT}"
           EAS_BRANCH="development"
         fi
         

--- a/.github/actions/git-version/action.yml
+++ b/.github/actions/git-version/action.yml
@@ -72,21 +72,21 @@ runs:
           fi
 
         elif [[ ${{ github.ref }} == refs/heads/main ]]; then
-          # Main branch push - isolate with git hash in runtime version
+          # Main branch push - isolate with stable beta runtime version
           # Increment minor version by 1 and reset patch to 0
           BASE_VERSION="${MAJOR}.$((MINOR + 1)).0"
           VERSION="v${BASE_VERSION}-beta.${COMMIT_COUNT}"
           FULL_VERSION="v${BASE_VERSION}-beta.${COMMIT_COUNT}+${GIT_HASH_SHORT}"
-          RUNTIME_VERSION="v${BASE_VERSION}-beta.${COMMIT_COUNT}"
+          RUNTIME_VERSION="v${BASE_VERSION}-beta"
           EAS_BRANCH="preview"
           
         else
-          # Other branch (manual trigger) - isolate with git hash in runtime version
+          # Other branch (manual trigger) - isolate with stable alpha runtime version
           # Increment minor version by 1 and reset patch to 0
           BASE_VERSION="${MAJOR}.$((MINOR + 1)).0"
           VERSION="v${BASE_VERSION}-alpha.${COMMIT_COUNT}"
           FULL_VERSION="v${BASE_VERSION}-alpha.${COMMIT_COUNT}+${GIT_HASH_SHORT}"
-          RUNTIME_VERSION="v${BASE_VERSION}-alpha.${COMMIT_COUNT}+${GIT_HASH_SHORT}"
+          RUNTIME_VERSION="v${BASE_VERSION}-alpha"
           EAS_BRANCH="development"
         fi
         

--- a/.github/workflows/eas-build-dev.yml
+++ b/.github/workflows/eas-build-dev.yml
@@ -42,6 +42,7 @@ jobs:
       run: eas build --platform android --profile development --wait
       env:
         CI: 1
+        APP_ENV: development
 
     - name: Get build artifact URL
       id: build-url

--- a/.github/workflows/eas-build-dev.yml
+++ b/.github/workflows/eas-build-dev.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     name: Build Dev Client APK
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     
     steps:
     - name: Checkout

--- a/app.config.js
+++ b/app.config.js
@@ -1,0 +1,21 @@
+module.exports = ({ config }) => {
+  const IS_DEV = process.env.APP_ENV === 'development';
+
+  return {
+    ...config,
+    // Add (Dev) suffix to app name during development
+    name: IS_DEV ? `${config.name} (Dev)` : config.name,
+    
+    // Set separate iOS bundle identifier for side-by-side installation
+    ios: {
+      ...config.ios,
+      bundleIdentifier: IS_DEV ? 'com.cardgame.tractor.dev' : 'com.cardgame.tractor',
+    },
+    
+    // Set separate Android package name for side-by-side installation
+    android: {
+      ...config.android,
+      package: IS_DEV ? 'com.cardgame.tractor.dev' : 'com.cardgame.tractor',
+    },
+  };
+};


### PR DESCRIPTION
This PR stabilizes the runtimeVersion calculations in the git-version action for the main branch (-beta) and development branches (-alpha) by omitting the dynamic commit count and git hash suffix. This ensures that development builds and preview builds can successfully receive and test Over-The-Air (OTA) updates using EAS Update without needing binary rebuilds for every new commit.