### PR TITLE
Override EAS Update channel dynamically for dev client

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -17,5 +17,16 @@ module.exports = ({ config }) => {
       ...config.android,
       package: IS_DEV ? 'com.cardgame.tractor.dev' : 'com.cardgame.tractor',
     },
+    
+    // Dynamically align the EAS Update channel to 'development' for dev clients
+    updates: {
+      ...config.updates,
+      requestHeaders: {
+        ...config.updates?.requestHeaders,
+        'expo-channel-name': IS_DEV 
+          ? 'development' 
+          : (config.updates?.requestHeaders?.['expo-channel-name'] || 'production'),
+      },
+    },
   };
 };


### PR DESCRIPTION
This PR adds the dynamic updates.requestHeaders.expo-channel-name override in app.config.js to set it to 'development' when APP_ENV=development. This isolates the development client builds from your production channel updates, solving the warning log: 'The channel name for EAS Update in AndroidManifest.xml is set to "production"'.