### PR TITLE
Align Dev Client update channel to preview

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -18,13 +18,13 @@ module.exports = ({ config }) => {
       package: IS_DEV ? 'com.cardgame.tractor.dev' : 'com.cardgame.tractor',
     },
     
-    // Dynamically align the EAS Update channel to 'development' for dev clients
+    // Dynamically align the EAS Update channel to 'preview' for dev clients
     updates: {
       ...config.updates,
       requestHeaders: {
         ...config.updates?.requestHeaders,
         'expo-channel-name': IS_DEV 
-          ? 'development' 
+          ? 'preview' 
           : (config.updates?.requestHeaders?.['expo-channel-name'] || 'production'),
       },
     },


### PR DESCRIPTION
This PR updates the dynamic 'app.config.js' configuration to set the default updates channel for development builds to 'preview' instead of 'development'. This aligns with the 'preview' channel where your 'main' branch beta updates are published, allowing seamless cloud OTA update testing.