### PR TITLE
Add Model Evaluation Skill and Adjust Bypass Latency

### DIFF
--- a/.agents/skills/model-evaluation/SKILL.md
+++ b/.agents/skills/model-evaluation/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: model-evaluation
+description: Instructions, templates, and scripts for evaluating and benchmarking different LLM models for Shengji strategic AI decision-making.
+version: 1.0.0
+license: MIT
+---
+
+## Overview
+
+The Model Evaluation skill provides structured tools, instructions, and scripts to benchmark different Large Language Models (LLMs) against the Tractor (Shengji) AI decision engine. 
+
+Evaluating models helps ensure:
+1. **Rule Compliance**: Selecting models that consistently generate valid plays (0% rule violations).
+2. **API/Connection Reliability**: Detecting sensitivity to rate limits (HTTP 429) or high latency timeouts.
+3. **Strategic Reasoning**: Evaluating the model's textual `reasoning` logs for elite positional play, defense protection, and trump management.
+4. **Performance Efficiency**: Benchmarking tokens-per-second, API request cost, and average turn duration.
+
+---
+
+## 1. Automated Multi-Model Benchmarking
+
+We provide a specialized, high-performance runner script (`evaluate-models.sh`) to automatically run sequential game simulations across different models and compile a comparative evaluation report.
+
+### A. Run Command (Default Models)
+To benchmark the standard model list (`deepseek/deepseek-chat`, `meta-llama/llama-3.3-70b-instruct`, `google/gemini-2.5-flash`), run:
+```bash
+./.agents/skills/model-evaluation/evaluate-models.sh
+```
+
+### B. Run Command (Custom Models)
+To evaluate specific models (e.g. Gemini 2.5 Pro and Llama 3.3):
+```bash
+./.agents/skills/model-evaluation/evaluate-models.sh "google/gemini-2.5-pro" "meta-llama/llama-3.3-70b-instruct"
+```
+
+### C. Options and Customization
+You can customize the evaluation length and tolerances:
+```bash
+# Run 1 game of 2 rounds per model with a high API error tolerance
+./.agents/skills/model-evaluation/evaluate-models.sh -g 1 -r 2 --max-api-errors 30 "deepseek/deepseek-chat"
+```
+
+---
+
+## 2. Model Evaluation Checklist
+
+When benchmarking a new model, evaluate it across the following four key pillars:
+
+### 1. Rules Compliance Rate (Gold Standard)
+* **Goal**: **100% compliance** (0 invalid plays).
+* **Metric**: `LLM Invalid Card Rule Violations Retried` and `LLM Invalid Card Retries Exhausted Fallbacks`.
+* **Verdict**: Models that frequently select cards not in their hand or fail to follow suit are unusable in production. DeepSeek V3 excels here.
+
+### 2. Error Fallback Resilience
+* **Goal**: Low fallback rate.
+* **Metric**: `LLM Plays API / Timeout Fallbacks`.
+* **Verdict**: Compares how often the model hits concurrency limits or upstream timeouts. If a model has a high fallback rate due to HTTP 429, a retry mechanism with exponential backoff or high-quota dedicated API keys should be utilized.
+
+### 3. Positional Strategic Play
+Review individual game logs in `logs/` to verify:
+* **Partner Points Protection**: Does the player play low non-points when the partner is winning?
+* **Trump Bleeding**: Does the leader force opponents' trumps out early?
+* **Void Setup**: Does the AI actively dump high non-points to exhaust a suit and set up truffs?
+
+### 4. Duration and Latency
+* **Goal**: Prompt completion < 3.0 seconds.
+* **Metric**: `Total Duration` and average turn duration.
+* **Verdict**: Faster models deliver a responsive player experience in-app.
+
+---
+
+## 3. Reference Table of Evaluated Models
+
+| Model | Success Rate | Rule Compliance | Latency | Strategic Verdict |
+| :--- | :--- | :--- | :--- | :--- |
+| **`deepseek/deepseek-chat` (V3)** | **~84%** (rate-limited) | **100%** | Medium-Low | **Excellent**: Demonstrates high positional awareness and flawless formatting compliance. |
+| **`meta-llama/llama-3.3-70b`** | High | High | Medium | **Very Good**: Solid reasoning, occasionally requires retry on complex card-id sorting. |
+| **`google/gemini-2.5-flash`** | Very High | High | Low | **Excellent Value**: Best speed/cost ratio; highly recommended for runtime. |

--- a/.agents/skills/model-evaluation/evaluate-models.sh
+++ b/.agents/skills/model-evaluation/evaluate-models.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+
+# Load .env file if it exists, respecting already set environment variables (local overrides)
+if [ -f .env ]; then
+    while IFS= read -r line || [ -n "$line" ]; do
+        # Strip leading/trailing whitespaces
+        line=$(echo "$line" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+        # Skip empty lines and comments
+        [[ -z "$line" || "$line" == \#* ]] && continue
+        
+        # Parse key and value
+        if [[ "$line" =~ ^([^=]+)=(.*)$ ]]; then
+            key="${BASH_REMATCH[1]}"
+            val="${BASH_REMATCH[2]}"
+            
+            # Trim key and value
+            key=$(echo "$key" | sed -e 's/[[:space:]]*$//')
+            val=$(echo "$val" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+            
+            # Strip enclosing quotes from value if present
+            if [[ ($val == \"*\" && $val == *\") || ($val == \'*\' && $val == *\') ]]; then
+                val="${val:1:-1}"
+            fi
+            
+            # Only export if the variable is not already defined in the shell environment
+            if ! declare -p "$key" &>/dev/null; then
+                export "$key"="$val"
+            fi
+        fi
+    done < .env
+fi
+
+# Default settings for evaluations
+TARGET_GAMES="1"
+MAX_ROUNDS="1"
+MAX_LLM_API_ERRORS="20"
+MAX_LLM_INVALID_PLAYS="20"
+
+# List of models to evaluate if not specified via arguments
+DEFAULT_MODELS=(
+    "deepseek/deepseek-chat"
+    "meta-llama/llama-3.3-70b-instruct"
+    "google/gemini-2.5-flash"
+)
+
+MODELS=()
+
+# Parse arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -g|--games)
+            TARGET_GAMES="$2"
+            shift 2
+            ;;
+        -r|--rounds)
+            MAX_ROUNDS="$2"
+            shift 2
+            ;;
+        --max-api-errors)
+            MAX_LLM_API_ERRORS="$2"
+            shift 2
+            ;;
+        --max-invalid-plays)
+            MAX_LLM_INVALID_PLAYS="$2"
+            shift 2
+            ;;
+        -h|--help)
+            echo "Shengji AI Multi-Model Evaluation Runner"
+            echo "Usage: ./.agents/skills/model-evaluation/evaluate-models.sh [options] [model1 model2 ...]"
+            echo ""
+            echo "Options:"
+            echo "  -g, --games <number>     Set number of target games per model (default 1)"
+            echo "  -r, --rounds <number>    Set maximum rounds per game (default 1)"
+            echo "  --max-api-errors <n>     Set maximum allowed API exceptions before aborting (default 20)"
+            echo "  --max-invalid-plays <n>  Set maximum allowed invalid plays/retries before aborting (default 20)"
+            echo "  -h, --help               Show this help message"
+            echo ""
+            echo "If no models are specified, it defaults to evaluating:"
+            echo "  - deepseek/deepseek-chat"
+            echo "  - meta-llama/llama-3.3-70b-instruct"
+            echo "  - google/gemini-2.5-flash"
+            exit 0
+            ;;
+        *)
+            MODELS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+if [ ${#MODELS[@]} -eq 0 ]; then
+    MODELS=("${DEFAULT_MODELS[@]}")
+fi
+
+export LLM_ENABLED="true"
+export TARGET_GAMES
+export MAX_ROUNDS
+export MAX_LLM_API_ERRORS
+export MAX_LLM_INVALID_PLAYS
+
+echo "================================================================="
+echo "        SHENGJI SIMULATION MULTI-MODEL STRATEGIC EVALUATION"
+echo "================================================================="
+echo "• Target Games:      $TARGET_GAMES"
+echo "• Max Rounds:        $MAX_ROUNDS"
+echo "• Max API Errors:    $MAX_LLM_API_ERRORS"
+echo "• Max Invalid Plays:  $MAX_LLM_INVALID_PLAYS"
+echo "• Models to test:    ${MODELS[*]}"
+echo "================================================================="
+echo ""
+
+# Temporary file to store parsed metrics
+RESULTS_FILE=$(mktemp)
+
+# Helper function to extract values from summary log
+get_val() {
+    local pattern="$1"
+    local file="$2"
+    if [ ! -f "$file" ]; then
+        echo "N/A"
+        return
+    fi
+    local res
+    res=$(grep -i "$pattern" "$file" | head -n 1 | sed -E 's/.*:[[:space:]]*//' | sed -E 's/^[[:space:]]*//')
+    if [ -z "$res" ]; then
+        echo "N/A"
+    else
+        echo "$res"
+    fi
+}
+
+# Run evaluations in a loop
+for model in "${MODELS[@]}"; do
+    echo "-----------------------------------------------------------------"
+    echo "🤖 STARTING EVALUATION FOR: $model"
+    echo "-----------------------------------------------------------------"
+    
+    export LLM_MODEL="$model"
+    
+    # Run simulation
+    npm run test:simulation
+    RUN_STATUS=$?
+    
+    # Locate the latest summary log file generated
+    LATEST_SUMMARY=$(ls -t logs/*-summary.txt 2>/dev/null | head -n 1)
+    
+    if [ $RUN_STATUS -ne 0 ] || [ -z "$LATEST_SUMMARY" ]; then
+        echo "❌ Evaluation crashed or failed to complete for $model"
+        echo "$model|ERROR|-|-|-|-|-" >> "$RESULTS_FILE"
+    else
+        echo "✅ Finished evaluation for $model"
+        
+        # Parse statistics
+        reqs=$(get_val "Total LLM Plays Requested" "$LATEST_SUMMARY")
+        success=$(get_val "Successful LLM Plays" "$LATEST_SUMMARY")
+        api_errs=$(get_val "LLM Plays API / Timeout Fallbacks" "$LATEST_SUMMARY")
+        violations=$(get_val "LLM Invalid Card Rule Violations Retried" "$LATEST_SUMMARY")
+        success_rate=$(get_val "Overall Telemetry Success Rate" "$LATEST_SUMMARY")
+        duration=$(get_val "Total Duration" "$LATEST_SUMMARY")
+        
+        # Format parsed values
+        [ "$reqs" = "N/A" ] && reqs="0"
+        [ "$success" = "N/A" ] && success="0"
+        [ "$api_errs" = "N/A" ] && api_errs="0"
+        [ "$violations" = "N/A" ] && violations="0"
+        [ "$success_rate" = "N/A" ] && success_rate="0.0%"
+        
+        echo "$model|OK|$reqs|$success|$api_errs|$violations|$success_rate|$duration" >> "$RESULTS_FILE"
+    fi
+    echo ""
+done
+
+# Print final comparison table
+echo "=========================================================================================="
+echo "                               MODEL STRATEGIC EVALUATION REPORT"
+echo "=========================================================================================="
+printf "%-35s | %-7s | %-12s | %-7s | %-9s | %-9s | %-9s\n" "MODEL ID" "STATUS" "REQS (SUCCESS)" "API ERR" "RULE VIOL" "SUCCESS %" "DURATION"
+echo "------------------------------------------------------------------------------------------"
+
+while IFS="|" read -r model status reqs success api_errs violations success_rate duration; do
+    if [ "$status" = "ERROR" ]; then
+        printf "%-35s | \e[31m%-7s\e[0s | %-12s | %-7s | %-9s | %-9s | %-9s\n" "$model" "CRASH" "-" "-" "-" "-" "-"
+    else
+        success_num=$(echo "$success" | cut -d' ' -f1)
+        printf "%-35s | \e[32m%-7s\e[0s | %-12s | %-7s | %-9s | %-9s | %-9s\n" "$model" "SUCCESS" "$reqs ($success_num)" "$api_errs" "$violations" "$success_rate" "$duration"
+    fi
+done < "$RESULTS_FILE"
+
+echo "=========================================================================================="
+echo "Telemetries and detailed turn reasonings have been saved under their respective log files"
+echo "in the logs/ directory. Check the latest summary file for a complete event breakdown."
+echo "=========================================================================================="
+
+rm -f "$RESULTS_FILE"

--- a/src/ai/following/followingStrategy.ts
+++ b/src/ai/following/followingStrategy.ts
@@ -361,26 +361,17 @@ export async function selectFollowingPlayAsync(
     currentPlayer.hand.some((c) => isTrump(c, trumpInfo))
   ) {
     // Engagement Point 1: Void in led suit, holds trumps — trump vs discard
-    engagementContext = {
-      dilemma: `We are VOID in the led suit (${leadingCards[0]?.suit ?? "Trump Group"}). Currently ${currentWinner} (Teammate Winning: ${isTeammateWinning}) is winning the trick with ${trickPoints} points. We hold trump cards and must decide: trump in to win, or save trumps and discard.`,
-      specificHelp: `Should we TRUMP-IN to win the trick, or DISCARD a non-trump card to save our trumps? If trumping, pick the lowest trump combo that beats the current winner. If discarding, pick the lowest useless card.`,
-    };
+    engagementContext = `We are VOID in the led suit (${leadingCards[0]?.suit ?? "Trump Group"}). Currently ${currentWinner} (Teammate Winning: ${isTeammateWinning}) is winning the trick with ${trickPoints} points. Decide whether to TRUMP-IN with the lowest trump combination to win, or DISCARD a low non-trump card to save trumps.`;
   } else if (
     analysis.scenario === "insufficient" ||
     (analysis.scenario === "void" &&
       !currentPlayer.hand.some((c) => isTrump(c, trumpInfo)))
   ) {
     // Engagement Point 2: Must discard off-suit — feed points vs deny points
-    engagementContext = {
-      dilemma: `We must DISCARD off-suit cards (not enough of the led suit). Currently ${currentWinner} (Teammate Winning: ${isTeammateWinning}) is winning with ${trickPoints} points in the trick.`,
-      specificHelp: `If our partner is winning safely, feed them point cards (5, 10, King) to secure points. If opponents are winning, discard our lowest non-point cards to deny them points. Choose which card(s) to discard.`,
-    };
+    engagementContext = `We must DISCARD off-suit cards. Currently ${currentWinner} (Teammate Winning: ${isTeammateWinning}) is winning with ${trickPoints} points in the trick. If our partner is winning safely, feed them point cards (5, 10, King) to secure points. If opponents are winning, play our lowest non-point card to deny points.`;
   } else {
     // Engagement Point 3: Multiple same-suit options — how aggressively to play
-    engagementContext = {
-      dilemma: `We have multiple cards or combos of the led suit to play. Currently ${currentWinner} (Teammate Winning: ${isTeammateWinning}) is winning with ${trickPoints} points. Decide: compete aggressively (high cards) or preserve high cards / combos.`,
-      specificHelp: `Should we play HIGH cards to beat opponents, or play LOW to preserve our pairs/tractors and high cards for later? Select the optimal cards from our hand.`,
-    };
+    engagementContext = `We have multiple cards of the led suit to play. Currently ${currentWinner} (Teammate Winning: ${isTeammateWinning}) is winning with ${trickPoints} points. Decide whether to play HIGH to beat opponents and win the trick, or play LOW to preserve our pairs/tractors and high cards for later.`;
   }
 
   gameLogger.debug("llm_following_engagement", {

--- a/src/ai/leading/leadingStrategy.ts
+++ b/src/ai/leading/leadingStrategy.ts
@@ -249,11 +249,7 @@ export async function selectLeadingPlayAsync(
     )
     .join("\n");
 
-  const engagementContext: LLMEngagementContext = {
-    dilemma:
-      "We need to choose which suit or combination to lead. We want to secure the lead, pressure opponents, avoid leading under opponents' voids, and avoid wasting point cards prematurely.",
-    specificHelp: `Evaluate our lead candidates. Help us choose the optimal leading play. Recommend the best option and explain your reasoning.\n\nCandidates evaluated by rule-based engine:\n${allOptionsStr}`,
-  };
+  const engagementContext: LLMEngagementContext = `Choose the optimal leading play from our candidates. Recommend the best option (considering non-trump Aces, bleeding trumps, void setups, and protecting point cards) and explain your reasoning. Candidates evaluated by rule-based engine:\n${allOptionsStr}`;
 
   gameLogger.debug("llm_leading_engagement", {
     playerId,

--- a/src/ai/llm/llmAIStrategy.ts
+++ b/src/ai/llm/llmAIStrategy.ts
@@ -52,14 +52,14 @@ export async function simulateLLMLatency(): Promise<void> {
 
   const avg = getAverageLLMDuration();
   if (avg === 0) {
-    // No LLM calls recorded yet — use a reasonable default (1–2s)
-    await new Promise((r) => setTimeout(r, 1000 + Math.random() * 1000));
+    // No LLM calls recorded yet — use a reasonable default centered on the 50%–75% of standard 1–2s (500–1500ms)
+    await new Promise((r) => setTimeout(r, 500 + Math.random() * 1000));
     return;
   }
 
-  // Random duration: 70%–130% of the rolling average, clamped to [500ms, 5000ms]
-  const jitter = 0.7 + Math.random() * 0.6;
-  const delay = Math.max(500, Math.min(5000, Math.round(avg * jitter)));
+  // Random duration: 50%–75% of the rolling average, clamped to [250ms, 3750ms]
+  const jitter = 0.50 + Math.random() * 0.25;
+  const delay = Math.max(250, Math.min(3750, Math.round(avg * jitter)));
 
   gameLogger.debug("llm_bypass_simulated_latency", { avg, delay });
   await new Promise((r) => setTimeout(r, delay));

--- a/src/ai/llm/llmGamePrompt.ts
+++ b/src/ai/llm/llmGamePrompt.ts
@@ -8,154 +8,45 @@ import {
 import { sortCards } from "../../utils/cardSorting";
 import { isTrump } from "../../game/cardValue";
 
-export interface LLMEngagementContext {
-  dilemma: string;
-  specificHelp: string;
-}
+export type LLMEngagementContext = string;
 
-export const STATIC_LLM_GAME_RULES = `# Shengji (升级 / Tractor) Advanced AI Knowledge Base & Strategic Guide
+export const STATIC_LLM_GAME_RULES = `# Shengji (升级 / Tractor) Advanced AI Strategic Rules
 
-This guide is an exhaustive reference for LLM-driven AI players to make elite strategic decisions in Shengji. It integrates every precise rule, tactical constraint, and strategic heuristic validated across our extensive unit test suites and advanced rule-based engine.
+## 1. Partnerships & Roles
+- **Teams**: Counter-clockwise: South (\`human\`) & North (\`bot2\`) [Team A] vs East (\`bot1\`) & West (\`bot3\`) [Team B].
+- **Goal**: Cooperate with partner to advance ranks from **2 to Ace** by winning rounds. The first team to reach rank **Ace** and successfully defend (hold attackers < 80 pts) wins the game.
+- **Scoring**: Defenders hold Attackers < 80 pts to advance. Attackers win by capturing 80+ pts.
+- **Rotation**: Attackers win -> next player counter-clockwise starts next round. Defenders win -> partner of previous starter starts.
+- **Kitty**: 8 cards are kept in the kitty and are completely out of active play during trick playing.
 
----
+## 2. Card Values & Trump Hierarchy
+- **Points**: 5 = 5pts, 10 = 10pts, King = 10pts (200 total).
+- **Trump Group**: Single unified suit. BJ > SJ > Trump-Suit Rank > Off-Suit Ranks (equal, first played wins) > Trump Suit Regulars (A > K > Q > ... > 3).
+- **Off-Suits**: A > K > Q > ... > 3. Cross-suit plays cannot beat each other.
 
-## 1. Partnerships, Play Flow & Phase Loops
+## 3. Combinations & Tractors
+- **Combos**: Single; Pair (2 identical cards); Tractor (2+ consecutive pairs in same suit/trump group).
+- **Trump Tractor Order**: A-Trump-Suit -> Off-Suit Ranks -> Trump-Suit Rank -> SJ -> BJ. Off-suit ranks must bridge through the trump-suit rank (e.g. 2♥2♥-2♣2♣ is invalid, 2♥2♥-2♠2♠ is valid).
+- **Skip Rule**: Off-suit tractor sequences skip the active Trump Rank (e.g., 6-8 is consecutive if 7 is active rank).
+- **Preservation**: Do not break a tractor to follow a pair if you have a standalone pair.
 
-- **Fixed Partnerships**: 
-  - **Team A**: 'human' (sitting South) and 'bot2' (sitting North).
-  - **Team B**: 'bot1' (sitting East) and 'bot3' (sitting West).
-  - Teammates sit opposite each other. Play proceeds counter-clockwise: **human -> bot1 -> bot2 -> bot3**.
-- **Role Mechanics**:
-  - **Defending Team**: Must hold the attacking team under 80 points to defend and advance their rank.
-  - **Attacking Team**: Must capture 80+ points in the round to take over the defend role and advance their rank.
-- **Round Starting Player Rotation**:
-  - **Attacking Team Wins**: The starting player for the next round is the next player counter-clockwise from the previous starter (e.g. Human starts -> Bot 1 starts next). Teams swap roles.
-  - **Defending Team Wins**: The partner of the previous starter starts the next round (e.g. Human starts -> Bot 2 starts next). Defending team remains defenders.
-  - **First Round**: The player who successfully declared trump starts the first trick of the first round.
+## 4. Following & Ruffing Priorities
+- **Priority**: 1. Follow suit/trump. 2. Match combo structure (tractor/pair) if possible. 3. Preserve pairs/tractors (do not break unnecessarily). 4. Play highest combos first (Anti-Cheat).
+- **Ruff/Discard**: If void, you can discard or cut with trump. To cut a combo, you must match its structure (e.g. trump pair cuts a pair; 2 single trumps cannot).
+- **Exhaustion**: If play leaves you with 0 cards of the led suit, any cards are valid.
 
----
+## 5. Multi-Combo Rules (Same-suit combos led together)
+- **Lead**: Non-trump only. Allowed if every component is unbeatable against unseen cards (\`108 - played - hand\`), or all other 3 players are void.
+- **Follow**: Match structure (tractors/pairs/singles) and total length. Void players can cut with matching trump structures.
+- **Trump vs Trump**: Compare highest component combo type (Tractor > Pair > Single), then compare highest card.
 
-## 2. The Trump Group & Card Strengths
-
-All trump cards are treated as a single, unified "suit" for following leads and matching combinations. Any trump card beats any non-trump card of any suit.
-
-### Trump Strength Hierarchy (Highest to Lowest)
-1. **Big Joker (BJ)** — Absolute highest card.
-2. **Small Joker (SJ)** — Second highest card.
-3. **Trump-Suit Rank Card** — Card matching both current Trump Rank and Trump Suit (e.g. 2♠ when Spades is trump, rank 2).
-4. **Off-Suit Rank Cards** — Cards matching current Trump Rank but of other suits (e.g. 2♥, 2♦, 2♣).
-   - *Equal Strength Rule*: All off-suit trump rank cards have equal strength; among them, the first one played in the trick wins.
-5. **Regular Trump Suit Cards** — Cards of the declared Trump Suit ranked by face value (A > K > Q > J > 10 > 9 > 8 > 7 > 6 > 5 > 4 > 3, excluding the rank card).
-
-### Regular Non-Trump Suits Hierarchy
-- Within each off-suit (Spades, Hearts, Clubs, Diamonds): **A > K > Q > J > 10 > 9 > 8 > 7 > 6 > 5 > 4 > 3**.
-- Cross-suit beats are invalid (e.g., a high Heart cannot beat a low Diamond unless it is played as a Trump-in).
-
-### Point Values
-- **5s** = 5 points | **10s** = 10 points | **Kings** = 10 points. All other cards are worth 0 points. Total points in deck = 200.
-
----
-
-## 3. Card Combinations & Tractor Formation
-
-- **Single**: Any individual card.
-- **Pair**: Exactly two IDENTICAL cards (same suit AND same rank, e.g. A♠-A♠ or SJ-SJ). Big Jokers only pair with Big Jokers; Small Jokers only with Small Jokers. Different suits or different jokers do NOT form a pair.
-- **Tractor**: Two or more consecutive pairs of the same suit or the unified trump group (minimum 2 pairs / 4 cards). Gaps are strictly validated.
-- **Tractor Skip Promoted Rank**: Since the round's active Trump Rank is promoted to the trump suit, off-suit consecutive sequences must skip this rank.
-  - *Example*: In a Rank 7 round, 6♠6♠ and 8♠8♠ skip 7 to form a consecutive tractor (6-8).
-- **Trump Group Tractor Sequences**: Consecutiveness within the trump group follows this sequence:
-  - **A of Trump Suit** -> **Off-Suit Trump Rank Pairs** -> **Trump-Suit Trump Rank Pair** -> **Small Joker Pair** -> **Big Joker Pair**.
-  - *Valid Trump Tractors*:
-    - A of Trump Suit + Off-Suit Trump Rank (e.g. A♣A♣-2♥2♥ when 2 is rank, Clubs is trump).
-    - Off-Suit Trump Rank + Trump-Suit Trump Rank (e.g. 2♥2♥-2♣2♣).
-    - Trump-Suit Trump Rank + Small Joker (e.g. 2♣2♣-SJSJ).
-    - Small Joker + Big Joker (e.g. SJSJ-BJBJ).
-  - *Constraint*: Off-suit rank pairs do NOT form tractors with each other (e.g. 2♥2♥-2♦2♦ is invalid). They must bridge through the trump-suit rank pair.
-- **Tractor Preservation Priority**: If a player holds a tractor (e.g. J♥J♥-Q♥Q♥) and a single pair is led, they must NOT break their tractor to play one of its pairs if they have an independent pair in hand.
-
----
-
-## 4. Following Rules & Preservation Priorities
-
-When a trick is led, followers must play the exact same number of cards and obey these strict priorities:
-1. **Priority 1: Count Match & Suit Following**: If you have cards of the led suit/group in hand, you MUST play them. If Trump is led, follow with trump cards (Jokers, rank cards, trump suit cards).
-2. **Priority 2: Tractor Matching**: If a tractor is led and you have a tractor of the same size in that suit, you must play it. If not, play as many pairs as possible to match the leading pairs.
-3. **Priority 3: Pair Preservation**: If a pair is led and you have a pair in the led suit, you must follow with a pair. Do not break up pairs or play singles instead. If you play one card of a pair, you must play the other card to avoid breaking/preservation violations.
-4. **Priority 4: Anti-Cheat (Highest Combos First)**: You must play your highest combinations in the led suit. You cannot play singles to "save" pairs.
-5. **Priority 5: Trump-in / Cutting Rules**:
-   - If void in the led suit, you can play trump cards to cut and win.
-   - Combination matching is strict for cutting: to beat a led pair, you must cut with a trump pair. Two single trumps do not count as a pair and cannot beat a pair.
-- **Suit Exhaustion Rule**: If playing cards will leave you with **0 cards** of the led suit remaining in hand, you can play any other cards to make up the trick length. This play is always valid.
-
----
-
-## 5. Multi-Combo Leading & Following Rules
-
-- **Multi-Combo**: Multiple combinations of the same suit played simultaneously (e.g. K♠K♠ + Q♠ + 7♠).
-- **Leading Multi-Combos**:
-  - Must strictly be a single non-trump suit. You **cannot** lead a trump multi-combo!
-  - Every component combination must be **unbeatable** against all outstanding cards, OR all other 3 players must be void in that suit.
-  - *Calculation*: The AI computes outstanding cards as: 'Total Cards (108) - playedCards - currentPlayer\\'sHand'.
-  - *Single Unbeatability*: All higher-ranking outstanding cards are accounted for.
-  - *Pair Unbeatability*: At least one card of each higher rank must be accounted for to prevent opponents from forming a higher pair.
-  - *Tractor Unbeatability*: If no bigger tractor exists outside your hand, it is unbeatable. Alternately, accounting for even one card of alternate higher ranks blocks opponents from forming any consecutive pair sequences.
-- **Following Multi-Combos**:
-  - **Structure Matching**: Follower must match the lead structure (number of tractors, pairs, singles) and exact total length as closely as possible.
-  - **Trump-In Structural Beating**: To beat a non-trump multi-combo, a void player must play matching structures of trump cards (e.g. 1 trump single + 1 trump pair to beat a lead of 1 single + 1 pair).
-  - **Trump vs Trump Over-ruffing**: Compare the highest combo type: Tractor > Pair > Single. If types match, compare the strength of the highest cards of that type.
-
----
-
-## 6. Defensive vs Offensive Trump Conservation
-
-The AI utilizes exact strategic conservation values to guide trump plays:
-'Big Joker (100) > Small Joker (90) > Trump Rank in Trump Suit (80) > Trump Rank Off-Suit (70) > Ace (60) > King (50) ... Trump Suit 5 (15) ... Weakest Trump Suit (5)'
-
-- Never waste high conservation cards on an opponent's unbeatable trick or when teammate is winning securely.
-- When forced to play trump, play cards with the lowest conservation value.
-- Exhaustion rules override conservation—if trump is led and a player has only high-value trumps, they must be played.
-
----
-
-## 7. AI Position-Aware Strategic Heuristics
-
-### 1st Player (Leader)
-- **Non-Trump Ace Leading**: Lead non-trump Aces (or Kings if Ace is the trump rank) early to win tricks safely and secure points.
-- **Trump Bleeding (Promotion-Bleed)**: Lead low trumps to bleed out opponents' low trumps, promoting the team's high trumps into guaranteed future winners.
-- **Trump Pair Leads (+40 bonus)**: Highly encouraged early as they exert immense pressure. Avoid leading single trumps early (heavy penalty).
-- **Teammate Void Setup**: Lead a suit where partner is void to let them trump-in and capture points.
-- **Never Lead Point Cards Prematurely**: Point cards (10s and Kings) carry a heavy penalty when led unless they are unbeatable.
-
-### 2nd Player (First Follower)
-- **Partner Winning**: Feed highest point cards ('King', 'Ten', 'Five') to teammate to maximize points captured.
-- **Opponent Strong Lead**: Play lowest possible non-point card (safe disposal) to conserve resources. If void and discarding (sloughing) from another suit, always choose a low non-point card. Never discard point cards (5s, 10s, Kings) into an opponent's winning trick.
-- **Opponent Moderate Lead**: Contest and block by playing a slightly higher card.
-- **Opponent Pair Lead**: Block with a higher pair (e.g. play 'A♠A♠' to beat opponent's 'KK' pair).
-- **Void on Opponent Point Lead**: Ruff with the **weakest available trump** to capture points cheaply.
-
-### 3rd Player (Second Follower)
-- **Teammate Strong Win**: Feed point cards. Priority: **10s before Kings before 5s** (to preserve the higher-ranking King card for future tricks).
-- **Teammate Weak Lead**: Play a stronger card (takeover) to secure the trick.
-- **Void, Next Opponent NOT Void**: Ruff with a **point trump** (e.g. '10♥') since the opponent must follow suit and cannot over-ruff.
-- **Void, Next Opponent ALSO Void**:
-  - *No points on table*: Ruff with a **low non-point trump** (e.g. '3♥') to force the opponent to over-ruff cheaply or let you win cheaply.
-  - *High points on table*: Ruff with a **very high trump card** (e.g. 'Ace♥') to prevent the opponent from over-ruffing easily.
-
-### 4th Player (Last Follower - Perfect Information)
-- **Teammate Secure Win**: Feed points aggressively ('10' > 'King' > '5'). **Avoid teammate competition**—do NOT play high trump rank cards or beat teammate's winning card.
-- **Opponent Win**: Play lowest possible non-point card (safe disposal). Conserve all valuable trump/pairs. If void and discarding (sloughing) from another suit, always choose a low non-point card. Never discard point cards (5s, 10s, Kings) into an opponent's winning trick.
-- **Over-Ruffing**: If void and opponent is winning a high-point trick, use a trump pair/single to secure it for the team.
-
-### Teammate Secure Win Identification (Memory Search)
-To determine if a teammate is winning securely, check the outstanding unseen cards:
-- Query unseen cards in the led suit from memory.
-- If no outstanding unseen combo can beat the teammate's current winning play, the teammate's win is **mathematically guaranteed**. Feed points safely.
-
-### Kitty Swap Phase Heuristics
-- **Point Card Protection**: Point cards ('5', '10', 'King') must be removed from the kitty and kept in the hand to prevent opponents from doubling/multiplying kitty points on the final trick.
-- **Trump Conservation**: Pull all trump cards from the kitty into the hand.
-- **Strategic Voiding**: Discard all cards of a weak non-trump suit (if very few exist) to create a void, enabling future ruffing opportunities. Do not break pairs.
-- **Final Trick Multiplier**: Scored only if the attacking team wins the final trick. Multiplier is **2x** for singles, **4x** for pairs, **8x** for tractors.
+## 6. Strategic Heuristics
+- **Conservation**: BJ (100) > SJ (90) > Trump Rank/Suit (80) > Trump Rank/Off-suit (70) > Ace (60) > King (50) ... Weakest Trump (5). Play lowest when forced or when partner wins.
+- **Leader (1st)**: Lead non-trump Aces/Kings early; lead trump pairs early (avoid single trumps). Setup void partner by playing point cards (5, 10, King) for them to trump securely. Play high non-points to void opponents to force trumps.
+- **2nd Player**: Partner winning -> feed points (K > 10 > 5). Opponent winning -> play lowest non-point. Void -> ruff with weakest trump.
+- **3rd Player**: Partner winning -> feed points (10 > K > 5). Take over trick if partner is weak. Void -> ruff point-tricks before last player: ruff point-trumps if last opponent must follow suit; ruff high if last opponent is void and might over-ruff.
+- **4th Player (Perfect Info)**: Partner winning -> feed points safely. Opponent winning -> lowest non-point. Void -> over-ruff to win.
+- **Kitty Awareness**: 8 cards are kept in the kitty and are completely out of active play during trick playing.
 `;
 
 /**
@@ -267,21 +158,7 @@ export function buildLLMUserPrompt(
 
   if (isLeading) {
     trickStateStr = `You are leading this trick!
-As the leader, you must play exactly ONE valid combination from your hand:
-1. **Single Card**: Select exactly 1 choice ID.
-2. **Pair**: Select exactly 2 IDENTICAL choice IDs (same suit and rank, e.g. two "10♠" cards or two "SJ" cards).
-3. **Tractor**: Select consecutive identical pairs (e.g. 10♠-10♠ and J♠-J♠, which is 4 cards total).
-4. **Multi-Combo**: Multiple combinations of the SAME non-trump suit (e.g. A♣ and K♣-K♣) only if they are unbeatable.
-
-*LEADER STRATEGY CHECKLIST:*
-- Prefer leading non-trump Aces/Kings early to win tricks safely and secure points.
-- AVOID leading single trump cards early (Jokers, rank cards) as they are wasted.
-- Trump pairs are highly encouraged to lead early as they exert immense pressure.
-- Avoid leading beatable point cards (10s and Kings) as opponents can capture them.
-- Dump short suits to create voids for future trumping-in opportunities.
-- You CANNOT lead a trump multi-combo (only non-trump suits allowed).
-- Mismatched combinations are strictly illegal (e.g., playing a single "3♣" and a single "5♣" together). Select exactly ONE combination type.
-`;
+As the leader, you must play exactly ONE valid combination from your hand (Single, Pair, Tractor, or unbeatable same-suit Multi-Combo). Mismatched combination types are strictly illegal.`;
   } else {
     const plays = currentTrick.plays;
     const leadPlay = plays[0];
@@ -315,38 +192,31 @@ You must play exactly ${requiredCount} card(s). You must follow the led suit/tru
 
     relevantCardsInfoStr = `
 === YOUR RELEVANT CARDS FOR THIS TRICK ===
-- Led suit/group is: ${isLeadingTrump ? "Trump Group (includes all Jokers, all " + trumpInfo.trumpRank + "s, and all " + (trumpInfo.trumpSuit || "None") + " cards)" : leadingSuit}
-- Number of cards in your hand belonging to this suit/group: ${matchingHandCards.length}
-- Choice IDs of these matching cards in your hand: ${matchingChoiceIds.length > 0 ? matchingChoiceIds.join(", ") : "None (You are void in this suit/group)"}
-
-*FOLLOWER PRIORITY CHECKLIST:*
+- Led suit/group is: ${isLeadingTrump ? "Trump Group (includes Jokers, " + trumpInfo.trumpRank + "s, and " + (trumpInfo.trumpSuit || "None") + " cards)" : leadingSuit}
+- Choice IDs of matching cards in hand: ${matchingChoiceIds.length > 0 ? matchingChoiceIds.join(", ") : "None (You are void)"}
 ${
   matchingHandCards.length >= requiredCount
-    ? `- You have enough matching cards! You MUST follow suit. Select exactly ${requiredCount} card ID(s) ONLY from your relevant cards list: [${matchingChoiceIds.join(", ")}]. Do NOT play cards from other suits.
-- If a Pair is led and you hold pairs, you MUST play a pair (Pair Preservation).
-- If a Tractor is led and you hold a tractor, you MUST play it. If you only hold pairs, play as many pairs as possible.
-- Anti-Cheat: You must play your highest combinations in the led suit first. You cannot break pairs to play singles.`
-    : `- You DO NOT have enough matching cards! You MUST play ALL ${matchingHandCards.length} of your relevant cards: [${matchingChoiceIds.join(", ")}] (Suit Exhaustion Rule).
-- For the remaining ${requiredCount - matchingHandCards.length} card(s), you must choose disposal/cutting cards of other suits from your hand. Do NOT select the same choice ID more than once.
-- If you choose to trump-in to win, your trump play must match or exceed the combination structure of the lead (e.g. trump pair to beat a led pair).
-- If you choose to discard (dispose/slough) because you cannot or do not want to trump, and opponents are winning the trick, ALWAYS select low non-point cards (worth 0 points). Never discard points (5s, 10s, or Kings) into an opponent's winning trick.`
+    ? `- You have enough matching cards and MUST follow suit. Select exactly ${requiredCount} card ID(s) ONLY from: [${matchingChoiceIds.join(", ")}].`
+    : `- You DO NOT have enough matching cards! You MUST play ALL ${matchingHandCards.length} matching card(s): [${matchingChoiceIds.join(", ")}]. Select any other ${requiredCount - matchingHandCards.length} card(s) of other suits to discard.`
 }
 `;
   }
 
-  // Reconstruct round tricks history
+  // Reconstruct round tricks history (limit to last 3 tricks to keep prompt light)
+  const recentTricks = gameState.tricks.slice(-3);
   const historyStr =
     gameState.tricks.length === 0
       ? "No tricks completed yet in this round."
-      : gameState.tricks
+      : recentTricks
           .map((t, idx) => {
+            const absoluteIdx = gameState.tricks.length - recentTricks.length + idx;
             const playsList = t.plays
               .map(
                 (p) =>
                   `${p.playerId} played ${p.cards.map((c) => c.toString()).join(", ")}`,
               )
               .join(", ");
-            return `Trick ${idx + 1}: Led by ${t.plays[0].playerId}. plays: [${playsList}]. Won by: ${t.winningPlayerId} (${t.points} points)`;
+            return `Trick ${absoluteIdx + 1}: Led by ${t.plays[0].playerId}. plays: [${playsList}]. Won by: ${t.winningPlayerId} (${t.points} points)`;
           })
           .join("\n");
 
@@ -366,36 +236,10 @@ ${
   let engagementSection = "";
   if (engagementContext) {
     engagementSection = `
-=== STRATEGIC DECISION POINT: SPECIFIC CONTEXT & HELP NEEDED ===
-- Strategic Dilemma: ${engagementContext.dilemma}
-- Specific Help Needed: ${engagementContext.specificHelp}
+=== STRATEGIC DECISION POINT: CONTEXT & SPECIFIC HELP ===
+- ${engagementContext}
 `;
   }
-
-  const rulesList: string[] = [];
-  if (!isLeading) {
-    rulesList.push(
-      `1. **EXACT CARD COUNT:** You MUST select EXACTLY ${requiredCount} card ID(s) from your hand! No more, no less. (e.g. if the count is ${requiredCount}, select exactly ${requiredCount} choice IDs, like ["c1", "c2"]).`,
-    );
-    rulesList.push(
-      `2. **Follow Led Suit:** You MUST play cards of the led suit/group if you have any. If Trump is led, follow with cards marked as Trump in your hand.`,
-    );
-    rulesList.push(
-      `3. **Pair Preservation & Tractor Priority:** Follow the strict structure-matching priorities (match led pairs/tractors and preserve your own combos as outlined in the system rules).`,
-    );
-    rulesList.push(
-      `4. **Position Heuristic compliance:** Apply position-aware strategies (feed winning teammate point cards, block opponent wins cheaply, conserve high trumps if trick has no points or teammate wins securely).`,
-    );
-  } else {
-    rulesList.push(
-      `1. **Valid Combinations Only:** Your play must form exactly ONE valid combination type (Single, Pair, Tractor, or unbeatable Multi-Combo of a single non-trump suit). Do NOT play a mismatched combination of random cards.`,
-    );
-    rulesList.push(
-      `2. **Leading Strategy:** Prefer non-trump Ace/King leads early. Lead low trumps to bleed opponents' trumps only when appropriate. Never lead point cards prematurely if beatable.`,
-    );
-  }
-
-  const rulesStr = rulesList.map((rule) => `${rule}`).join("\n");
 
   const userPrompt = `${engagementSection}
 === CURRENT STATE ===
@@ -411,13 +255,9 @@ ${trickStateStr}
 === CURRENT PLAYS IN THIS TRICK ===
 ${playsInTrickStr}
 
-=== KNOWN PLAYER SUIT VOIDS (WHO HAS EMPTIED SUITS) ===
-Based on completed tricks in this round:
+=== CONFIRMED PLAYER SUIT VOIDS (WHO HAS FAILED TO FOLLOW SUIT) ===
+These players are 100% confirmed void because they failed to follow suit in a previous trick. Note: Other players may also be void if they recently played their last card of a suit, but they are not yet confirmed:
 ${voidsStr}
-
-*Use this void information strategically:*
-- If an opponent is void in a suit, do NOT lead that suit with high-value cards unless you want to force them to use a trump card to cut it.
-- If your partner is void in a suit, leading that suit can let them trump-in (cut) to win the trick and capture points!
 
 === ROUND HISTORY (PREVIOUS TRICKS) ===
 ${historyStr}
@@ -429,19 +269,8 @@ Your hand has ${handCards.length} cards remaining. Select from these choices by 
 }
 
 === TASK ===
-Select the best card(s) from your hand to play. Your selection must contain exactly the required number of cards and obey all Shengji following/preservation rules.
-
-*** CRITICAL GAMEPLAY RULES (MUST OBEY): ***
-${rulesStr}
-
-Respond with a JSON object using EXACTLY these two keys:
-- "reasoning": A brief explanation of your strategic decision (string)
-- "play": An array of card choice IDs to play (e.g. ["c1"] or ["c3", "c4"])
-
-Example response format:
-{"reasoning": "Leading with Ace of Spades to probe opponent voids and secure points.", "play": ["c2"]}
-
-Do not include markdown code block syntax (\`\`\`json) in your raw response. Output the JSON object directly.
+Select exactly the required number of cards following Shengji rules. Output ONLY a raw JSON object (no markdown \`\`\`json wrappers) matching this format:
+{"reasoning": "brief strategic explanation here", "play": ["c1", "c2"]}
 `;
 
   const systemPrompt = buildLLMSystemPrompt(gameState);


### PR DESCRIPTION
This PR introduces a dedicated model-evaluation skill (complete with SKILL.md and evaluate-models.sh) to support automated benchmarking, and adjusts the simulated bypass latency to range from 50% to 75% of the rolling average.