### PR TITLE
Refine 4th player heuristic and update prompt-refinement skill

### DIFF
--- a/.agents/skills/prompt-refinement/SKILL.md
+++ b/.agents/skills/prompt-refinement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prompt-refinement
-description: Instructions, heuristics, and strategies for merging new game strategic knowledge into LLM prompts without bloating.
+description: Instructions, heuristics, and strategies for integrating new game strategic knowledge into LLM prompts without bloating.
 version: 1.0.0
 license: MIT
 ---
@@ -9,7 +9,7 @@ license: MIT
 
 The **Prompt Refinement** skill provides a rigorous, highly disciplined workflow for improving the strategic decision-making context of Shengji (Tractor) AI bots. 
 
-When you find a game scenario where the LLM makes a suboptimal tactical choice, use this skill to diagnose, draft, and cleanly merge strategic context into the system prompt (`STATIC_LLM_GAME_RULES` in [llmGamePrompt.ts](file:///home/eric/repos/Tractor/src/ai/llm/llmGamePrompt.ts)).
+When you find a game scenario where the LLM makes a suboptimal tactical choice, use this skill to diagnose, draft, and cleanly integrate strategic context into the system prompt (`STATIC_LLM_GAME_RULES` in [llmGamePrompt.ts](file:///home/eric/repos/Tractor/src/ai/llm/llmGamePrompt.ts)).
 
 ---
 
@@ -21,7 +21,7 @@ When you find a game scenario where the LLM makes a suboptimal tactical choice, 
 
 ### 2. Harmonious Integration & Structured Refactoring
 * **Rule**: Do not append arbitrary, isolated rules (e.g., *"Rule 7: Never play 5♣ on trick 2"*). Instead, integrate the logic seamlessly. You can:
-  1. **Merge** it into an existing section (Hierarchy, Ruffing, or Heuristics).
+  1. **Incorporate** it into an existing section (Hierarchy, Ruffing, or Heuristics).
   2. **Create a new dedicated section** if the topic introduces a completely new strategic dimension (e.g., `## 7. Kitty Discarding Strategy`).
   3. **Rewrite or refactor** existing sections entirely if the current phrasing is too limiting or confusing.
 * **Tactic**: Align additions with the core structural sections:
@@ -39,46 +39,49 @@ When you find a game scenario where the LLM makes a suboptimal tactical choice, 
 
 ## 🔄 The Prompt Refinement Workflow
 
+> [!IMPORTANT]
+> **Non-Blocking Execution**: Prompt refinement only alters system prompt strings. Do NOT create pre-execution implementation plans or block on approval loops. Instead, apply the prompt edits directly to `llmGamePrompt.ts` first, and then stop to wait for the user to review the file changes.
+
 ```mermaid
 graph TD
-    A[Identify Suboptimal Play in Logs] --> B[Pinpoint Prompt Gap in llmGamePrompt.ts]
+    A[Identify Suboptimal Play from User or Logs] --> B[Pinpoint Prompt Gap in llmGamePrompt.ts]
     B --> C[Draft Heuristic with Motivation & Intent]
-    C --> D[Refactor & Merge into Existing Sections]
+    C --> D[Refactor & Integrate into Prompt]
     D --> E[Stop & Wait for User Review]
 ```
 
-### Step 1: Diagnose the Log
-Examine the game log (e.g., under `logs/`). Note:
-* Who was the leader? Who was currently winning?
-* What cards did the LLM have, and what suboptimal choice did it make?
-* What was the strategic intent that the LLM failed to understand?
+### Step 1: Identify and Diagnose the Suboptimal Play
+Determine the details of the suboptimal play based on the user's report or game logs:
+* Which player had the turn? What were the team roles and the current trick state (e.g., points on the table, winning player)?
+* What cards did the bot have, and what suboptimal card choice did it make?
+* What was the strategic intent that the bot failed to understand?
 
 ### Step 2: Pinpoint the Prompt Gap
-Open [llmGamePrompt.ts](file:///home/eric/repos/Tractor/src/ai/llm/llmGamePrompt.ts) and locate the relevant section of `STATIC_LLM_GAME_RULES`. Ask yourself:
-* Why did the model make this choice?
-* Was a heuristic missing?
-* Was an existing rule confusing or ambiguous?
+Locate the relevant section of `STATIC_LLM_GAME_RULES` in `llmGamePrompt.ts`. Diagnose why the prompt allowed or caused the bad play:
+* Was the strategic heuristic completely missing?
+* Was an existing rule confusing, ambiguous, or too generic?
+* Were there conflicting rules?
 
 ### Step 3: Draft the Contextual Heuristic
-Formulate the lesson as a clear, context-aware principle that explains **why** and **when** a player should make this choice.
-* *Poor: "If you have a 10 and King, play King."*
-* *Better: "Prioritize feeding high-value point cards (King, 10) to secure the trick when your teammate is winning, or conserve them when opponents have won the trick."*
+Formulate the lesson as a clear, context-aware strategic principle that explains **why** and **when** a player should make the correct choice (using motivational language, not hard state-machine rules).
+* *Poor*: "If you have a 10 and King, play King."
+* *Better*: "Prioritize feeding high-value point cards (King, 10) to secure the trick when your teammate is winning, or conserve them when opponents have won the trick."
 
-### Step 4: Compress and Merge
-* Locate the exact lines in `STATIC_LLM_GAME_RULES` where this fits (usually `## 6. Strategic Heuristics`).
-* Merge it into the existing bullet points. If needed, re-write or tighten the adjacent rules to save space.
+### Step 4: Compress and Integrate
+Update `llmGamePrompt.ts` to integrate the new heuristic:
+* Locate the appropriate section (usually `## 6. Strategic Heuristics` or the relevant following priorities).
+* Do not just append a new bullet point (to avoid prompt bloat). Instead, compress, rewrite, or tighten the adjacent rules to maintain a strict token budget.
 
 ### Step 5: Stop & Wait for User Review
-
-Once prompt refinements are merged:
-- **Always stop and wait for the user to review the changes.**
+Once the changes are applied:
+- **Stop and wait for the user to review the file changes directly.**
 - **DO NOT build** the project.
 - **DO NOT run qualitycheck** (`npm run qualitycheck` or similar).
 - **DO NOT commit** any changes.
 
 ---
 
-## 💡 Example: Merging Heuristics Harmoniously
+## 💡 Example: Integrating Heuristics Harmoniously
 
 ### Scenario
 An AI bot led a low trump card on trick 1 when it had high non-trump Aces. 
@@ -91,7 +94,7 @@ An AI bot led a low trump card on trick 1 when it had high non-trump Aces.
 ```
 *Why this is bad*: It creates a redundant, overly specific hard rule that doesn't build understanding.
 
-### Professional Merge (DO this)
+### Professional Integration (DO this)
 ```diff
  ## 6. Strategic Heuristics
 - - Leader (1st): Lead non-trump Aces/Kings early; lead trump pairs early (avoid single trumps). Setup void teammate...

--- a/src/ai/llm/llmGamePrompt.ts
+++ b/src/ai/llm/llmGamePrompt.ts
@@ -30,9 +30,9 @@ export const STATIC_LLM_GAME_RULES = `# Shengji (升级 / Tractor) Advanced AI S
 - **Preservation**: Do not break a tractor to follow a pair if you have a standalone pair.
 
 ## 4. Following & Ruffing Priorities
-- **Priority**: 1. Follow suit/trump. 2. Match combo structure (tractor/pair) if possible. 3. Preserve pairs/tractors (do not break unnecessarily). 4. If you cannot fully match the combo structure, play your highest available combination types (e.g. play pairs if tractor led).
-- **Ruff/Discard**: If void, you can discard or cut with trump. To cut a combo, you must match its structure (e.g. trump pair cuts a pair; 2 single trumps cannot).
-- **Exhaustion**: If play leaves you with 0 cards of the led suit, any cards are valid.
+- **Priority**: 1. Follow suit. 2. Match combo structure (pair/tractor) if possible. 3. Do not break pairs/tractors unnecessarily. 4. If unable to match structure, play highest available component types (e.g., pairs for led tractor).
+- **Ruff/Discard**: If void, you can discard or trump (ruff). To trump a combo, you must match its structure (e.g. trump pair trumps a pair; 2 singles cannot). Deciding whether to trump depends on points on the table and potential points remaining players may add: trump to secure high points or block opponents; conserve trumps on low-point tricks.
+- **Exhaustion**: If out of the led suit, any cards are valid.
 
 ## 5. Multi-Combo Rules (Same-suit combos led together)
 - **Lead**: Non-trump only. Allowed if every component is unbeatable against unseen cards (\`108 - played - hand\`), or all other 3 players are void.
@@ -41,10 +41,10 @@ export const STATIC_LLM_GAME_RULES = `# Shengji (升级 / Tractor) Advanced AI S
 
 ## 6. Strategic Heuristics
 - **Conservation**: Retain highest trumps (BJ > SJ > Trump Ranks > Trump Regulars: A > K > ... > 3) and off-suit boss cards (Aces > Kings); play lowest (non-point/low trump regulars) when forced or teammate wins.
-- **Leader (1st)**: Controls the trick start and tempo. Lead off-suit Aces/Kings early; lead trump pairs (avoid single trumps). High trumps (Jokers, Active Ranks, and High Trump Regulars like Aces/Kings) are precious control assets; leading them early (especially as singletons) is inefficient unless holding sufficient trumps to exhaust opponents' trumps and run long off-suits. Feed point cards (5, 10, K) if teammate is void. Play high non-points to force out opponent trumps.
-- **2nd Player**: Decide whether to win or conserve, evaluating that your teammate (4th Player) plays last and can cover the trick. If opponents lead points and you hold the boss card (e.g. Ace), it is a prime opportunity to win immediately, unless conserving it. Otherwise, play lowest non-point to conserve resources and allow the 4th Player to win or contest. Void -> ruff with modest trump to win or block.
-- **3rd Player**: Vital blocking role because the last player is an opponent (4th) playing with perfect info. If teammate is winning and their card is strong, prioritize feeding point cards (10 > K > 5) and conserving non-point boss cards; only play high or ruff to secure a vulnerable trick. If void, ruff or over-ruff to secure points or block and pressure the opponent, but avoid ruffing teammate's dominant winning cards.
-- **4th Player (Perfect Info)**: Final play with perfect info. If teammate is winning, feed points safely; however, you can strategically beat a winning teammate or opponent (even on point-free tricks) to secure the lead if needed to run a powerful combination (unbeatable tractor/long suit) next. If opponent is winning and you cannot or choose not to win, play lowest non-point to conserve.
+- **Leader (1st)**: Controls tempo. Lead off-suit Aces/Kings early; lead trump pairs (avoid single trumps). High trumps (Jokers, Ranks, Aces/Kings) are precious; leading them early (especially singletons) is inefficient unless holding enough to exhaust opponents and run off-suits. Feed points (5, 10, K) if teammate is void. Play high non-points to force out opponent trumps.
+- **2nd Player**: Decide to win or conserve, knowing teammate (4th) plays last and can cover. If opponents lead points and you hold the boss (e.g., Ace), it is a prime opportunity to win immediately. Otherwise, play lowest non-point to conserve and let 4th player contest. Void -> trump to win/block based on table points and potential remaining plays.
+- **3rd Player**: Vital blocking role. If teammate is winning and strong, prioritize feeding points (10 > K > 5) and conserving boss cards; play high or trump only to secure vulnerable tricks. If void, trump/over-trump to secure points or pressure opponents (based on table and potential points), but avoid trumping teammate's winning cards.
+- **4th Player (Perfect Info)**: Last to act. If teammate is winning, feed points safely (10 > K > 5). If opponent is winning: if void, trump/over-trump (ruff/over-ruff) to win the trick and capture points (especially when high points are on the table); if you cannot win or choose not to, discard lowest non-point to conserve and NEVER feed points to opponents. You can also strategically beat a winning teammate/opponent to secure the lead if you hold powerful combos (e.g., unbeatable tractors) to lead next.
 `;
 
 /**


### PR DESCRIPTION
This PR introduces two main improvements:
1. **Strategic Prompt Refinement**: Updated `llmGamePrompt.ts` to teach the AI that the decision to trump (ruff) when void depends critically on the points currently on the table and potential points from subsequent players. Specifically refined the 4th Player logic to use perfect information to ruff/over-ruff for high points, or cleanly discard the lowest non-point card without feeding points to a winning opponent.
2. **Skill File Polish**: Completely refactored `SKILL.md` for prompt-refinement to fix confusing Git-centric 'merge' terminology, correct invalid log paths, and implement a streamlined, non-blocking workflow model.