### PR TITLE
feat(llm): refine LLM prompts, hand sections, void discard rules, and engagementContext

### DIFF
--- a/.agents/skills/prompt-refinement/SKILL.md
+++ b/.agents/skills/prompt-refinement/SKILL.md
@@ -71,6 +71,7 @@ Formulate the lesson as a clear, context-aware strategic principle that explains
 Update `llmGamePrompt.ts` to integrate the new heuristic:
 * Locate the appropriate section (usually `## 6. Strategic Heuristics` or the relevant following priorities).
 * Do not just append a new bullet point (to avoid prompt bloat). Instead, compress, rewrite, or tighten the adjacent rules to maintain a strict token budget.
+* **Also check `engagementContext` strings** (see below) — if the new heuristic affects a scenario they cover, update those strings too.
 
 ### Step 5: Stop & Wait for User Review
 Once the changes are applied:
@@ -78,6 +79,26 @@ Once the changes are applied:
 - **DO NOT build** the project.
 - **DO NOT run qualitycheck** (`npm run qualitycheck` or similar).
 - **DO NOT commit** any changes.
+
+---
+
+## 🎯 Engagement Context (`engagementContext`)
+
+The `engagementContext` is a **per-decision-point supplement** that augments the static system prompt with live situational awareness at the moment of each LLM call. It is defined in two files:
+
+- **[followingStrategy.ts](file:///home/eric/repos/Tractor/src/ai/following/followingStrategy.ts)** — Three scenarios triggered at decision time:
+  1. **Void with trumps**: Player is void in led suit and holds trumps — trump vs. discard dilemma.
+  2. **Must discard**: Player is void with no trumps, or card count is insufficient — point feeding vs. denial.
+  3. **Multiple same-suit options**: Player can follow suit with multiple cards — play high vs. preserve strength.
+
+- **[leadingStrategy.ts](file:///home/eric/repos/Tractor/src/ai/leading/leadingStrategy.ts)** — One scenario:
+  1. **Ambiguous lead**: Multiple candidates scored by the rule engine — LLM picks the best option with reasoning.
+
+### Consistency Rules
+When refining `STATIC_LLM_GAME_RULES`, **always check `engagementContext` strings** for consistency:
+* Use the same terminology (e.g., `Trump Group`, `Active Ranks`, `Off-Suit <Suit>`) that matches the hand sections shown in the user prompt.
+* Maintain consistent point priority order (e.g., `10 > King > 5`).
+* If you introduce a new concept (e.g., a new discard rule), ensure the relevant `engagementContext` string references or reinforces it, not contradicts it.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ Use `gameLogger` instead of `console.log()`
 
 ## Git Workflow
 
-> **IMPORTANT**: Never commit to main branch. Never commit automatically.
+> **IMPORTANT**: Never commit to main branch. Never commit automatically, and never commit code until the user explicitly asks.
 
 ```bash
 # 1. Create feature branch

--- a/src/ai/following/followingStrategy.ts
+++ b/src/ai/following/followingStrategy.ts
@@ -361,17 +361,17 @@ export async function selectFollowingPlayAsync(
     currentPlayer.hand.some((c) => isTrump(c, trumpInfo))
   ) {
     // Engagement Point 1: Void in led suit, holds trumps — trump vs discard
-    engagementContext = `We are VOID in the led suit (${leadingCards[0]?.suit ?? "Trump Group"}). Currently ${currentWinner} (Teammate Winning: ${isTeammateWinning}) is winning the trick with ${trickPoints} points. Decide whether to TRUMP-IN with the lowest trump combination to win, or DISCARD a low non-trump card to save trumps.`;
+    engagementContext = `We are VOID in the led suit (look at your hand's "Off-Suit ${leadingCards[0]?.suit ?? "Trump Group"}" section — it shows void). ${currentWinner} is currently winning (Teammate Winning: ${isTeammateWinning}) with ${trickPoints} points. Decide whether to TRUMP-IN from your "Trump Group" section with the lowest sufficient trump combination to win, or DISCARD a low non-point card from another off-suit section to save trumps.`;
   } else if (
     analysis.scenario === "insufficient" ||
     (analysis.scenario === "void" &&
       !currentPlayer.hand.some((c) => isTrump(c, trumpInfo)))
   ) {
     // Engagement Point 2: Must discard off-suit — feed points vs deny points
-    engagementContext = `We must DISCARD off-suit cards. Currently ${currentWinner} (Teammate Winning: ${isTeammateWinning}) is winning with ${trickPoints} points in the trick. If our partner is winning safely, feed them point cards (5, 10, King) to secure points. If opponents are winning, play our lowest non-point card to deny points.`;
+    engagementContext = `We must DISCARD off-suit cards (we are void or have insufficient cards of the led suit). ${currentWinner} is currently winning (Teammate Winning: ${isTeammateWinning}) with ${trickPoints} points. If teammate is winning safely, feed point cards (10 > King > 5) to secure points. If opponents are winning, NEVER discard points — play our lowest non-point card from another off-suit section to deny free points.`;
   } else {
     // Engagement Point 3: Multiple same-suit options — how aggressively to play
-    engagementContext = `We have multiple cards of the led suit to play. Currently ${currentWinner} (Teammate Winning: ${isTeammateWinning}) is winning with ${trickPoints} points. Decide whether to play HIGH to beat opponents and win the trick, or play LOW to preserve our pairs/tractors and high cards for later.`;
+    engagementContext = `We have multiple cards of the led suit to play (see the relevant hand section). ${currentWinner} is currently winning (Teammate Winning: ${isTeammateWinning}) with ${trickPoints} points. Decide whether to play HIGH to beat opponents and win the trick, or play LOW (preserving Active Ranks, pairs/tractors, and high cards) for future control.`;
   }
 
   gameLogger.debug("llm_following_engagement", {

--- a/src/ai/leading/leadingStrategy.ts
+++ b/src/ai/leading/leadingStrategy.ts
@@ -249,7 +249,7 @@ export async function selectLeadingPlayAsync(
     )
     .join("\n");
 
-  const engagementContext: LLMEngagementContext = `Choose the optimal leading play from our candidates. Recommend the best option (considering non-trump Aces, bleeding trumps, void setups, and protecting point cards) and explain your reasoning. Candidates evaluated by rule-based engine:\n${allOptionsStr}`;
+  const engagementContext: LLMEngagementContext = `Choose the optimal leading play from the candidates below. Your hand is grouped into \"Trump Group\" and off-suit sections (strongest to weakest). Consider: leading off-suit Aces/Kings early for control; leading trump pairs to bleed opponents; conserving Active Ranks and Jokers; setting up void suits. Explain your reasoning. Candidates scored by rule-based engine:\n${allOptionsStr}`;
 
   gameLogger.debug("llm_leading_engagement", {
     playerId,

--- a/src/ai/llm/llmGamePrompt.ts
+++ b/src/ai/llm/llmGamePrompt.ts
@@ -20,7 +20,8 @@ export const STATIC_LLM_GAME_RULES = `# Shengji (升级 / Tractor) Advanced AI S
 
 ## 2. Card Values & Trump Hierarchy
 - **Points**: 5 = 5pts, 10 = 10pts, King = 10pts (200 total).
-- **Trump Group**: Single unified suit. BJ > SJ > Trump-Suit Rank > Off-Suit Ranks (equal, first played wins) > Trump Suit Regulars (A > K > Q > ... > 3). Off-Suit Ranks and Jokers are irreplaceable — when forced to discard trumps, sacrifice the weakest Trump Suit Regulars first.
+- **Trump Group**: Single unified suit. BJ > SJ > Trump-Suit Rank > Off-Suit Ranks (equal, first played wins) > Trump Suit Regulars (A > K > Q > ... > 3). Off-Suit Ranks and Jokers are irreplaceable.
+- **Active Ranks**: The Trump-Suit Rank and Off-Suit Ranks are "Active Ranks" and are second only to Jokers in strength. They are extremely powerful control assets and NOT low-value cards (e.g. if the active rank is 7, a 7 beats an Ace). When forced to discard or follow suit without winning, sacrifice the weakest Trump Suit Regulars (3, 4, 6...) first; NEVER throw away Active Ranks or Jokers as fodder.
 - **Off-Suits**: Cards of the trump rank leave their off-suit and join the Trump Group. Remaining cards rank A > K > Q > ... > 3 (or K > Q > ... > 3 if Ace is active rank); the highest card left in its suit is unbeatable unless cut by trump. Cross-suit plays cannot beat each other.
 
 ## 3. Combinations & Tractors
@@ -31,7 +32,10 @@ export const STATIC_LLM_GAME_RULES = `# Shengji (升级 / Tractor) Advanced AI S
 
 ## 4. Following & Ruffing Priorities
 - **Priority**: 1. Follow suit. 2. Match combo structure (pair/tractor) if possible. 3. Do not break pairs/tractors unnecessarily. 4. If unable to match structure, play highest available component types (e.g., pairs for led tractor).
-- **Ruff/Discard**: If void, you can discard or trump (ruff). To trump a combo, you must match its structure (e.g. trump pair trumps a pair; 2 singles cannot). Deciding whether to trump depends on points on the table and potential points remaining players may add: trump to secure high points or block opponents; conserve trumps on low-point tricks.
+- **Ruff/Discard (Void Player)**: If void, you can discard (sluff) or trump (ruff). To trump a combo, you must match its structure (e.g. trump pair trumps a pair; 2 singles cannot).
+  - **Discard Rule**: If you choose to discard (sluff) or cannot trump: if opponents are winning or likely to win, **NEVER discard point cards (5, 10, K)** as it hands them free points; instead, discard your lowest non-point card of another suit. Feed points **ONLY** when your teammate is winning the trick.
+  - **Trump Rule**: Trump to secure high-point tricks or block opponents; conserve your trumps on low-point or unbeatable tricks.
+- **Conserve Strength on Follows**: When following a trick that you cannot win or where your teammate is winning overwhelmingly, **conserve your high cards** (Active Ranks, high Trump Regulars A/K, and Jokers); follow with your lowest available cards of the led suit to avoid wasting precious control assets.
 - **Exhaustion**: If out of the led suit, any cards are valid.
 
 ## 5. Multi-Combo Rules (Same-suit combos led together)
@@ -40,11 +44,11 @@ export const STATIC_LLM_GAME_RULES = `# Shengji (升级 / Tractor) Advanced AI S
 - **Trump vs Trump**: Compare highest component combo type (Tractor > Pair > Single), then compare highest card.
 
 ## 6. Strategic Heuristics
-- **Conservation**: Retain highest trumps (BJ > SJ > Trump Ranks > Trump Regulars: A > K > ... > 3) and off-suit boss cards (Aces > Kings); play lowest (non-point/low trump regulars) when forced or teammate wins.
-- **Leader (1st)**: Controls tempo. Lead off-suit Aces/Kings early; lead trump pairs (avoid single trumps). High trumps (Jokers, Ranks, Aces/Kings) are precious; leading them early (especially singletons) is inefficient unless holding enough to exhaust opponents and run off-suits. Feed points (5, 10, K) if teammate is void. Play high non-points to force out opponent trumps.
-- **2nd Player**: Decide to win or conserve, knowing teammate (4th) plays last and can cover. If opponents lead points and you hold the boss (e.g., Ace), it is a prime opportunity to win immediately. Otherwise, play lowest non-point to conserve and let 4th player contest. Void -> trump to win/block based on table points and potential remaining plays.
-- **3rd Player**: Vital blocking role. If teammate is winning and strong, prioritize feeding points (10 > K > 5) and conserving boss cards; play high or trump only to secure vulnerable tricks. If void, trump/over-trump to secure points or pressure opponents (based on table and potential points), but avoid trumping teammate's winning cards.
-- **4th Player (Perfect Info)**: Last to act. If teammate is winning, feed points safely (10 > K > 5). If opponent is winning: if void, trump/over-trump (ruff/over-ruff) to win the trick and capture points (especially when high points are on the table); if you cannot win or choose not to, discard lowest non-point to conserve and NEVER feed points to opponents. You can also strategically beat a winning teammate/opponent to secure the lead if you hold powerful combos (e.g., unbeatable tractors) to lead next.
+- **Conservation**: Retain highest trumps (BJ > SJ > Active Ranks > Trump Regulars: A > K > ... > 3) and off-suit boss cards (Aces > Kings). When forced to play to a trick you cannot win or when teammate is winning overwhelmingly, play your lowest available cards (non-point/low regulars) and **never** waste Active Ranks or Jokers as throwaway fodder.
+- **Leader (1st)**: Controls tempo. Lead off-suit Aces/Kings early; lead trump pairs (avoid single trumps). High trumps (Jokers, Active Ranks, Aces/Kings) are precious; leading them early (especially singletons) is inefficient unless holding enough to exhaust opponents and run off-suits. Feed points (5, 10, K) if teammate is void. Play high non-points to force out opponent trumps.
+- **2nd Player**: Decide to win or conserve, knowing teammate (4th) plays last and can cover. If opponents lead points and you hold the boss (e.g., Ace), it is a prime opportunity to win immediately. Otherwise, play lowest non-point to conserve and let 4th player contest. Void -> if you choose to discard instead of trumping, **never discard points to opponents**; play lowest non-point of another suit.
+- **3rd Player**: Vital blocking role. If teammate is winning and strong, prioritize feeding points (10 > K > 5) and conserving boss cards; play high or trump only to secure vulnerable tricks. If void, trump/over-trump to secure points or pressure opponents (based on table and potential points), but avoid trumping teammate's winning cards; if choosing to discard, **never discard points to opponents**.
+- **4th Player (Perfect Info)**: Last to act. If teammate is winning, feed points safely (10 > K > 5). If opponent is winning: if void, trump/over-trump (ruff/over-ruff) to win the trick and capture points (especially when high points are on the table); if you cannot win or choose not to, discard lowest non-point to conserve and **NEVER feed points to opponents** by discarding point cards. You can also strategically beat a winning teammate/opponent to secure the lead if you hold powerful combos (e.g., unbeatable tractors) to lead next.
 `;
 
 /**
@@ -140,9 +144,45 @@ export function buildLLMUserPrompt(
     cardInstance: card,
   }));
 
-  const choicesStr = choicesMap
-    .map((c) => `"${c.id}": "${c.display}"`)
-    .join(",\n  ");
+  // Group choices by category
+  const categories: Record<string, typeof choicesMap> = {};
+  choicesMap.forEach((choice) => {
+    let cat = "Off-Suit " + choice.cardInstance.suit;
+    if (choice.cardInstance.isTrump(trumpInfo)) {
+      cat = "Trump Group";
+    }
+    if (!categories[cat]) {
+      categories[cat] = [];
+    }
+    categories[cat].push(choice);
+  });
+
+  const categoryOrder = [
+    "Trump Group",
+    "Off-Suit Spades",
+    "Off-Suit Hearts",
+    "Off-Suit Clubs",
+    "Off-Suit Diamonds",
+  ];
+  const allCategories = [...categoryOrder];
+  Object.keys(categories).forEach((cat) => {
+    if (!allCategories.includes(cat)) {
+      allCategories.push(cat);
+    }
+  });
+
+  const choicesStr = allCategories
+    .map((cat) => {
+      const catCards = categories[cat] || [];
+      if (catCards.length === 0) {
+        return `--- ${cat.toUpperCase()} (void) ---`;
+      }
+      const catChoices = catCards
+        .map((c) => `  ${c.id}: ${c.display}`)
+        .join("\n");
+      return `--- ${cat.toUpperCase()} (${catCards.length} cards) ---\n${catChoices}`;
+    })
+    .join("\n\n");
 
   // Determine current trick state
   const currentTrick = gameState.currentTrick;
@@ -172,9 +212,9 @@ You must play exactly ${requiredCount} card(s). You must follow the led suit/tru
       )
       .join("\n");
 
-    // Dynamic hand analysis of led suit/group
     const isLeadingTrump = leadPlay.cards.some((c) => isTrump(c, trumpInfo));
     const leadingSuit = leadPlay.cards[0].suit;
+    const ledSuitDisplay = isLeadingTrump ? "Trump Group" : `Off-Suit ${leadingSuit}`;
 
     const matchingHandCards = isLeadingTrump
       ? handCards.filter((c) => isTrump(c, trumpInfo))
@@ -182,19 +222,12 @@ You must play exactly ${requiredCount} card(s). You must follow the led suit/tru
         (c) => c.suit === leadingSuit && !isTrump(c, trumpInfo),
       );
 
-    const matchingChoiceIds = choicesMap
-      .filter((c) =>
-        matchingHandCards.some((hc) => hc.id === c.cardInstance.id),
-      )
-      .map((c) => c.id);
-
     relevantCardsInfoStr = `
 === YOUR RELEVANT CARDS FOR THIS TRICK ===
-- Led suit/group is: ${isLeadingTrump ? "Trump Group (includes Jokers, " + trumpInfo.trumpRank + "s, and " + (trumpInfo.trumpSuit || "None") + " cards)" : leadingSuit}
-- Choice IDs of matching cards in hand: ${matchingChoiceIds.length > 0 ? matchingChoiceIds.join(", ") : "None (You are void)"}
+- Led suit/group is: ${ledSuitDisplay}
 ${matchingHandCards.length >= requiredCount
-        ? `- You have enough matching cards and MUST follow suit. Select exactly ${requiredCount} card ID(s) ONLY from: [${matchingChoiceIds.join(", ")}].`
-        : `- You DO NOT have enough matching cards! You MUST play ALL ${matchingHandCards.length} matching card(s): [${matchingChoiceIds.join(", ")}]. Select any other ${requiredCount - matchingHandCards.length} card(s) of other suits to discard.`
+        ? `- You hold ${matchingHandCards.length} matching card(s) in your hand's corresponding section and MUST follow suit. Select exactly ${requiredCount} card ID(s) ONLY from that section.`
+        : `- You only hold ${matchingHandCards.length} matching card(s) in that section! You MUST play ALL of them. For the remaining ${requiredCount - matchingHandCards.length} card(s), you can either discard (sluff) cards from other off-suit sections, or play TRUMP cards from your "Trump Group" section to trump (ruff) and try to win the trick!`
       }
 `;
   }
@@ -245,7 +278,6 @@ ${matchingHandCards.length >= requiredCount
 - Your Team: Team ${teamId} (Teammate: ${partnerId})
 - Current Round Trump Rank: ${trumpInfo.trumpRank}
 - Current Round Trump Suit: ${trumpInfo.trumpSuit || "None"}
-- Led Suit of this trick: ${gameState.currentTrick && gameState.currentTrick.plays[0] ? (isTrump(gameState.currentTrick.plays[0].cards[0], trumpInfo) ? "Trump Group" : gameState.currentTrick.plays[0].cards[0].suit) : "N/A (You are leading)"}
 ${relevantCardsInfoStr}
 === TRICK STATE ===
 ${trickStateStr}
@@ -260,11 +292,10 @@ ${voidsStr}
 === ROUND HISTORY (PREVIOUS TRICKS) ===
 ${historyStr}
 
-=== YOUR HAND (SORTED BY SUIT & STRENGTH) ===
+=== YOUR HAND (GROUPED BY SUIT & SORTED FROM STRONGEST TO WEAKEST) ===
 Your hand has ${handCards.length} cards remaining. Select from these choices by their IDs:
-{
-  ${choicesStr}
-}
+
+${choicesStr}
 
 === TASK ===
 Select exactly the required number of cards following Shengji rules. Output ONLY a raw JSON object (no markdown \`\`\`json wrappers) matching this format:


### PR DESCRIPTION
This PR refines the LLM game prompts, hand presentation format, void player discard/ruff strategic rules, and updates both leading and following strategies for complete consistency.

### Changes Included:
- **llmGamePrompt.ts**:
  - Defined 'Active Ranks' to prevent AI players from misinterpreting high cards as low values.
  - Rewrote the Ruff/Discard sections with explicit Discard rules (never feed points to opponents) and Trump rules.
  - Sectioned and grouped hand display (Trump Group, Off-Suit Spades/Hearts/Clubs/Diamonds) sorted strongest-to-weakest with explicit `(void)` indicators for empty suits.
  - Streamlined context info in user prompt by replacing the redundant `Led Suit` line with section-relative guidelines in `RELEVANT CARDS`.
- **followingStrategy.ts & leadingStrategy.ts**:
  - Realigned all `engagementContext` strings to use the new hand section terminology and consistent terminology.
- **Prompt Refinement Skill (SKILL.md)**:
  - Added documentation on `engagementContext` and alignment instructions for future prompt edits.
- **Git workflow update (AGENTS.md)**:
  - Clarified manual commit/PR rules.