### PR TITLE
Revert audio mode configuration and remove expo-av

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -7,7 +7,7 @@ import { useFonts } from "expo-font";
 import { Stack } from "expo-router";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { StatusBar } from "expo-status-bar";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import {
   Platform,
   StatusBar as RNStatusBar,
@@ -16,7 +16,6 @@ import {
   View,
 } from "react-native";
 import "react-native-reanimated";
-import { Audio, InterruptionModeAndroid, InterruptionModeIOS } from "expo-av";
 
 import { useColorScheme } from "react-native";
 
@@ -111,26 +110,6 @@ export default function RootLayout() {
   const [loaded] = useFonts({
     SpaceMono: require("../assets/fonts/SpaceMono-Regular.ttf"),
   });
-
-  useEffect(() => {
-    async function configureAudio() {
-      try {
-        await Audio.setAudioModeAsync({
-          playsInSilentModeIOS: true,
-          allowsRecordingIOS: false,
-          staysActiveInBackground: false,
-          interruptionModeIOS: InterruptionModeIOS.MixWithOthers,
-          interruptionModeAndroid: InterruptionModeAndroid.DuckOthers,
-          shouldDuckAndroid: true,
-          playThroughEarpieceAndroid: false,
-        });
-      } catch (error) {
-        // eslint-disable-next-line no-console
-        console.warn("Failed to configure audio mode:", error);
-      }
-    }
-    configureAudio();
-  }, []);
 
   if (!loaded) {
     // Async font loading only occurs in development.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "eslint-config-expo": "~56.0.4",
         "expo": "~56.0.4",
         "expo-asset": "~56.0.14",
-        "expo-av": "^16.0.8",
         "expo-constants": "~56.0.14",
         "expo-dev-client": "~56.0.15",
         "expo-font": "~56.0.5",
@@ -7182,23 +7181,6 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
-      }
-    },
-    "node_modules/expo-av": {
-      "version": "16.0.8",
-      "resolved": "https://registry.npmjs.org/expo-av/-/expo-av-16.0.8.tgz",
-      "integrity": "sha512-cmVPftGR/ca7XBgs7R6ky36lF3OC0/MM/lpgX/yXqfv0jASTsh7AYX9JxHCwFmF+Z6JEB1vne9FDx4GiLcGreQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*",
-        "react": "*",
-        "react-native": "*",
-        "react-native-web": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-web": {
-          "optional": true
-        }
       }
     },
     "node_modules/expo-constants": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "eslint-config-expo": "~56.0.4",
     "expo": "~56.0.4",
     "expo-asset": "~56.0.14",
-    "expo-av": "^16.0.8",
     "expo-constants": "~56.0.14",
     "expo-dev-client": "~56.0.15",
     "expo-font": "~56.0.5",


### PR DESCRIPTION
Reverts the commit that added expo-av and its startup setup to fix the native crash on launch and restore the clean package dependency state.