### PR TITLE
Upgrade expo-audio to match Expo SDK 56 to fix Android reified type crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "eslint-config-expo": "~56.0.4",
         "expo": "~56.0.4",
         "expo-asset": "~56.0.14",
-        "expo-audio": "~0.3.1",
+        "expo-audio": "~56.0.11",
         "expo-constants": "~56.0.14",
         "expo-dev-client": "~56.0.15",
         "expo-font": "~56.0.5",
@@ -7185,12 +7185,13 @@
       }
     },
     "node_modules/expo-audio": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/expo-audio/-/expo-audio-0.3.5.tgz",
-      "integrity": "sha512-gzpDH3vZI1FDL1Q8pXryACtNIW+idZ/zIZ8WqdTRzJuzxucazrG2gLXUS2ngcXQBn09Jyz4RUnU10Tu2N7/Hgg==",
+      "version": "56.0.11",
+      "resolved": "https://registry.npmjs.org/expo-audio/-/expo-audio-56.0.11.tgz",
+      "integrity": "sha512-naionxilr49IpEjmMqCj5gXHCSfOsgu3nZ/KXndexR05Tv6dET7dmespyZkcMrADJN07gA5hyqPUC5WqWuaFLw==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
+        "expo-asset": "*",
         "react": "*",
         "react-native": "*"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eslint-config-expo": "~56.0.4",
     "expo": "~56.0.4",
     "expo-asset": "~56.0.14",
-    "expo-audio": "~0.3.1",
+    "expo-audio": "~56.0.11",
     "expo-constants": "~56.0.14",
     "expo-dev-client": "~56.0.15",
     "expo-font": "~56.0.5",


### PR DESCRIPTION
Fixes the Android startup crash where `expo-audio` registers its native module and throws a Kotlin `throwUndefinedForReified` exception. This was caused by a version mismatch: the project was using Expo SDK 56 but `expo-audio` was set to `~0.3.1`. Upgrading `expo-audio` to `~56.0.11` aligns the native Kotlin compiled standard libraries and compiler signatures, resolving the crash.