### PR TITLE
Add dynamic seat-guidance layer to LLM following prompt

### DIFF
--- a/.agents/skills/prompt-refinement/SKILL.md
+++ b/.agents/skills/prompt-refinement/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: prompt-refinement
 description: This skill should be used when the user wants to improve how the Shengji (Tractor) LLM bots play by editing their prompt — e.g. "the bot made a bad play", "fix the LLM strategy prompt", "add a heuristic to the prompt", "the AI keeps mis-playing X", "rewrite the LLM rules". Covers BOTH the static system prompt (STATIC_LLM_GAME_RULES) and the dynamic user prompt, both in src/ai/llm/llmPromptTemplates.ts.
-version: 1.2.0
+version: 1.3.0
 license: UNLICENSED
 ---
 
@@ -14,11 +14,19 @@ The **Prompt Refinement** skill provides a rigorous, disciplined workflow for im
 Both live in [src/ai/llm/llmPromptTemplates.ts](file:src/ai/llm/llmPromptTemplates.ts):
 
 1. **System prompt — `STATIC_LLM_GAME_RULES`**: the static, game-wide strategic rules (card hierarchy, combos, following/ruffing, leading, position play). This is the bot's standing "how to play" knowledge.
-2. **User prompt — `buildUserPromptTemplate`**: the per-decision template. It is filled in by `buildLLMUserPrompt` and its helpers in [src/ai/llm/llmGamePrompt.ts](file:src/ai/llm/llmGamePrompt.ts) with the dynamic context for THIS decision: the hand grouped by suit (strongest→weakest, with `[pts]`/`(Trump)` tags), recent trick history, confirmed player voids, the active trick status, the **Trick Win Security** verdict (SECURED / LIKELY WIN / UNCERTAIN), and either **candidate lead options each with a Rule Score** (when leading) or a **suit-following analysis** (when following).
+2. **User prompt — `buildUserPromptTemplate`**: the per-decision template, filled in by `buildLLMUserPrompt` and its helpers in [src/ai/llm/llmGamePrompt.ts](file:src/ai/llm/llmGamePrompt.ts) with the dynamic context for THIS decision: the hand grouped by suit (strongest→weakest, with `[pts]`/`(Trump)` tags), recent trick history, confirmed player voids, a **Points still live** readout (unseen point cards per off-suit, via `localFormatLiveOffSuitPoints`), the active trick status, the **Trick Win Security** verdict (SECURED / LIKELY WIN / UNCERTAIN), and either **candidate lead options each with a Rule Score** (when leading) or a **suit-following analysis** plus a **Guidance for this seat** bullet (when following — see below).
 
 A prompt fix may belong in EITHER part. Before editing, decide which:
 - **Static gap** (the bot doesn't understand a general principle) → refine `STATIC_LLM_GAME_RULES`.
-- **Dynamic gap** (the bot lacks, or misreads, a per-decision signal) → improve what `buildUserPromptTemplate` / `llmGamePrompt.ts` surface, or how the static rules tell the bot to interpret those signals.
+- **Dynamic gap** (the bot lacks, or misreads, a per-decision signal) → improve what `buildUserPromptTemplate` / `llmGamePrompt.ts` surface (including the seat-guidance decision table, below), or how the static rules tell the bot to interpret those signals.
+
+### The dynamic seat-guidance layer
+
+When following, `localBuildSeatGuidance` (in `llmGamePrompt.ts`) injects a single **GUIDANCE FOR THIS SEAT** bullet — the engine's situation-specific *application* of the static following rules. It branches on facts the engine has already computed (seat, who's still to act, teammate-winning + whether safe, points on table, trump-vs-off-suit lead, void scenario) and spells out the inference a small model otherwise has to derive itself (e.g. *"a regular trump K/10 loses to active ranks/jokers, so don't pour a point card in"*). The system prompt tells the model to treat this block as its primary instruction.
+
+This is a deliberate split: the static rules (§5 following order, §6 ruffing, §9 position cues) are the **general framework and reference**; the seat-guidance bullet is the **focused, named-player application** for THIS decision. The point is to move the rule-selection-and-application step out of the small model and into code — so prefer fixing the decision table when a following misplay is really "the right rule existed but the model didn't apply it here".
+
+**Consistency requirement:** the seat-guidance branches mirror static §5/§6/§9, and `localFormatLiveOffSuitPoints` must match how the static rules talk about points. When you change one side, check the other — they must not diverge or contradict, and the guidance must stay *scaffolding for the LLM's judgement among legal options*, never a re-implementation of the rule-based AI's card choice.
 
 ### Key context
 
@@ -69,7 +77,7 @@ graph TD
 ### Step 2: Pinpoint the Gap
 Decide whether the gap is in the **static rules** (`STATIC_LLM_GAME_RULES`) or the **dynamic user prompt** (`buildUserPromptTemplate` / `llmGamePrompt.ts`):
 - Was a strategic heuristic missing, confusing, ambiguous, or conflicting? → static.
-- Did the model lack a signal, or was a provided signal (Rule Score, Win Security, voids, suit analysis) unclear or unused? → dynamic, or a static instruction on how to read it.
+- Did the model lack a signal, or was a provided signal (Rule Score, Win Security, voids, suit analysis, Points-still-live, the seat-guidance bullet) unclear, unused, or wrong? → dynamic: fix what the helpers surface or the `localBuildSeatGuidance` table (keeping it aligned with static §5/§6/§9), or add a static instruction on how to read the signal.
 
 ### Step 3: Draft the Contextual Heuristic
 Formulate the lesson as a clear, context-aware principle explaining **why** and **when**, in motivational language.
@@ -77,7 +85,7 @@ Formulate the lesson as a clear, context-aware principle explaining **why** and 
 - *Better*: "When your teammate's win is secured, feed your highest sparable point card but keep the stronger one — give the 10, keep the King."
 
 ### Step 4: Compress and Integrate
-Edit the correct file. Do not just append a bullet — compress, rewrite, or tighten adjacent text to hold the token budget. Keep the system prompt and user prompt consistent (e.g. if the static rules reference a "Rule Score" or "Trick Win Security" verdict, ensure the user prompt still emits those exact labels).
+Edit the correct file. Do not just append a bullet — compress, rewrite, or tighten adjacent text to hold the token budget. Keep the system prompt and user prompt consistent (e.g. if the static rules reference a "Rule Score" or "Trick Win Security" verdict, ensure the user prompt still emits those exact labels). If you touch the `localBuildSeatGuidance` decision table, keep its branches aligned with static §5/§6/§9 — a divergence here reads to the model as a contradiction.
 
 ### Step 5: Stop & Wait for User Review
 Once changes are applied:

--- a/src/ai/llm/llmGamePrompt.ts
+++ b/src/ai/llm/llmGamePrompt.ts
@@ -1,6 +1,8 @@
 import {
   Card,
   GameState,
+  GameContext,
+  MemoryContext,
   PlayerId,
   getPartnerId,
   TrumpInfo,
@@ -16,68 +18,30 @@ import { analyzeSuitAvailability } from "../following/suitAvailabilityAnalysis";
 import { detectCandidateLeads } from "../leading/candidateLeadDetection";
 import { collectLeadingContext } from "../leading/leadingContext";
 import { scoreNonTrumpLead, scoreTrumpLead } from "../leading/leadingScoring";
-import {
-  isPlayerOnAttackingTeam,
-  getCurrentAttackingPoints,
-} from "../aiGameContext";
+import { createGameContext } from "../aiGameContext";
 import {
   STATIC_LLM_GAME_RULES,
   buildUserPromptTemplate,
 } from "./llmPromptTemplates";
 
 /**
- * Analyzes the completed tricks in the round to detect which players have emptied (are void in) which suits.
- * A player has emptied a suit if they failed to follow the led suit of a trick.
+ * Projects the engine's per-player void memory into the string shape the prompt
+ * consumes: off-suit voids by name plus "Trump Group" when a player is out of
+ * trump. Reusing MemoryContext keeps the LLM path on the same void detection as
+ * the rule-based AI (which also accounts for the in-progress trick).
  */
-export function detectSuitVoidsFromHistory(
-  gameState: GameState,
-  trumpInfo: TrumpInfo,
-): Record<PlayerId, string[]> {
-  const voids: Record<PlayerId, Set<string>> = {
-    human: new Set<string>(),
-    bot1: new Set<string>(),
-    bot2: new Set<string>(),
-    bot3: new Set<string>(),
-  };
-
-  gameState.tricks.forEach((trick) => {
-    if (trick.plays.length === 0) return;
-
-    const leadPlay = trick.plays[0];
-    const leadCard = leadPlay.cards[0];
-    if (!leadCard) return;
-
-    const isTrumpLead = leadCard.isTrump(trumpInfo);
-    const ledSuit = isTrumpLead ? "Trump Group" : leadCard.suit;
-
-    trick.plays.forEach((play) => {
-      const playerCard = play.cards[0];
-      if (!playerCard) return;
-
-      const playerPlayedTrump = playerCard.isTrump(trumpInfo);
-
-      // Determine if player followed the led suit
-      let followedSuit = false;
-      if (isTrumpLead) {
-        followedSuit = playerPlayedTrump;
-      } else {
-        followedSuit = !playerPlayedTrump && playerCard.suit === ledSuit;
-      }
-
-      if (!followedSuit) {
-        // Player did not follow suit, so they are void (empty) in the led suit!
-        voids[play.playerId].add(ledSuit);
-      }
-    });
+function localVoidsFromMemory(
+  memoryContext: MemoryContext,
+): Record<string, string[]> {
+  const voids: Record<string, string[]> = {};
+  Object.values(memoryContext.playerMemories).forEach((pm) => {
+    const suits = Array.from(pm.suitVoids).map((s) => `${s}`);
+    voids[pm.playerId] = [
+      ...suits,
+      ...(pm.trumpVoid ? ["Trump Group"] : []),
+    ].sort();
   });
-
-  // Convert sets to sorted arrays for deterministic output
-  return {
-    human: Array.from(voids.human).sort(),
-    bot1: Array.from(voids.bot1).sort(),
-    bot2: Array.from(voids.bot2).sort(),
-    bot3: Array.from(voids.bot3).sort(),
-  };
+  return voids;
 }
 
 /**
@@ -266,6 +230,8 @@ function localBuildFollowingPromptContext(
   playerId: PlayerId,
   trumpInfo: TrumpInfo,
   cardToDisplay: (card: Card) => string,
+  gameContext: GameContext,
+  voids: Record<string, string[]>,
 ): {
   activeTrickStatusStr: string;
   taskInstructionStr: string;
@@ -273,7 +239,8 @@ function localBuildFollowingPromptContext(
   seatGuidanceStr: string;
 } {
   const currentTrick = gameState.currentTrick;
-  if (!currentTrick || currentTrick.plays.length === 0) {
+  const trickWinner = gameContext.trickWinnerAnalysis;
+  if (!currentTrick || currentTrick.plays.length === 0 || !trickWinner) {
     return {
       activeTrickStatusStr: "",
       taskInstructionStr: "",
@@ -285,10 +252,10 @@ function localBuildFollowingPromptContext(
   const plays = currentTrick.plays;
   const leadPlay = plays[0];
   const requiredCount = leadPlay.cards.length;
-  const winningPlayerId = currentTrick.winningPlayerId || leadPlay.playerId;
+  const winningPlayerId = trickWinner.currentWinner;
   const partnerId = getPartnerId(playerId);
-  const isTeammateWinning = winningPlayerId === partnerId;
-  const trickPoints = currentTrick.points || 0;
+  const isTeammateWinning = trickWinner.isTeammateWinning;
+  const trickPoints = trickWinner.trickPoints;
 
   const leadingCardsStr = leadPlay.cards.map((c) => c.toString()).join(", ");
 
@@ -307,11 +274,10 @@ function localBuildFollowingPromptContext(
 
   const remainingOpponents = yetToPlay.filter((id) => id !== partnerId);
 
-  // Analyze suit voids from history
+  // Confirmed voids come from the engine's MemoryContext (passed in).
   const leadCard = leadPlay.cards[0];
-  const isTrumpLead = leadCard?.isTrump(trumpInfo) || false;
+  const isTrumpLead = trickWinner.isTrumpLead;
   const ledSuit = isTrumpLead ? "Trump Group" : leadCard?.suit || "";
-  const voids = detectSuitVoidsFromHistory(gameState, trumpInfo);
   const isAnyOpponentVoid = remainingOpponents.some((oppId) => {
     const oppVoids = voids[oppId] || [];
     return oppVoids.includes(ledSuit);
@@ -321,24 +287,18 @@ function localBuildFollowingPromptContext(
   const winningCard = winningPlay?.cards[0] || null;
   const winningCardStr = winningCard ? winningCard.toString() : "their card";
 
-  // Cards already played this round plus those on the table — the memory used
-  // for unbeatable detection. The current player's own hand is passed separately.
-  const playedAndTable: Card[] = [
-    ...gameState.tricks.flatMap((t) => t.plays.flatMap((pl) => pl.cards)),
-    ...plays.flatMap((pl) => pl.cards),
-  ];
-
   // "Boss" is an OFF-SUIT notion only: the highest card still live in a side
-  // suit, beatable only by a ruff. Memory-aware via isComboUnbeatable — a K
-  // becomes boss once both Aces are gone. (isComboUnbeatable returns false for
-  // trump, so this is naturally off-suit only.)
+  // suit, beatable only by a ruff. Memory-aware via isComboUnbeatable (fed the
+  // engine's played-card memory) — a K becomes boss once both Aces are gone.
+  // Only meaningful for teammate-win safety below, so skip it otherwise.
   const winnerOffSuitBoss =
+    isTeammateWinning &&
     !!winningCard &&
     !winningCard.isTrump(trumpInfo) &&
     isComboUnbeatable(
       { type: ComboType.Single, cards: [winningCard], value: 0 },
       winningCard.suit,
-      playedAndTable,
+      gameContext.memoryContext.playedCards,
       handCards,
       trumpInfo,
       [],
@@ -526,11 +486,7 @@ function localFormatRecentTricksHistory(gameState: GameState): string {
 /**
  * Helper to format confirmed player suit voids.
  */
-function localFormatPlayerVoids(
-  gameState: GameState,
-  trumpInfo: TrumpInfo,
-): string {
-  const voids = detectSuitVoidsFromHistory(gameState, trumpInfo);
+function localFormatPlayerVoids(voids: Record<string, string[]>): string {
   return Object.entries(voids)
     .map(
       ([pId, suitsList]) =>
@@ -610,6 +566,11 @@ export function buildLLMUserPrompt(
   // Render a card as the plain notation the LLM also replies with
   const cardToDisplay = (card: Card): string => card.toString();
 
+  // Build the engine's game context once — single source for trick-winner
+  // analysis and per-player void memory (shared with the rule-based AI).
+  const gameContext = createGameContext(gameState, playerId);
+  const voids = localVoidsFromMemory(gameContext.memoryContext);
+
   // Determine current trick state
   const currentTrick = gameState.currentTrick;
   const isLeading = !currentTrick || currentTrick.plays.length === 0;
@@ -638,6 +599,8 @@ export function buildLLMUserPrompt(
       playerId,
       trumpInfo,
       cardToDisplay,
+      gameContext,
+      voids,
     );
     activeTrickStatusStr = context.activeTrickStatusStr;
     taskInstructionStr = context.taskInstructionStr;
@@ -648,8 +611,8 @@ export function buildLLMUserPrompt(
   // Reconstruct round tricks history (limit to last 3 tricks to keep prompt light)
   const historyStr = localFormatRecentTricksHistory(gameState);
 
-  // Detect suit voids per player from round trick history
-  const voidsStr = localFormatPlayerVoids(gameState, trumpInfo);
+  // Confirmed per-player voids from the engine's memory context
+  const voidsStr = localFormatPlayerVoids(voids);
 
   // Point cards still unseen in each off-suit (others' hands or hidden kitty)
   const liveSuitPointsStr = localFormatLiveOffSuitPoints(gameState, handCards);
@@ -657,8 +620,6 @@ export function buildLLMUserPrompt(
   const currentPlayer = gameState.players.find((p) => p.id === playerId);
   const teamId = currentPlayer?.team || "A";
   const partnerId = getPartnerId(playerId);
-  const isAttacking = isPlayerOnAttackingTeam(gameState, playerId);
-  const attackingPoints = getCurrentAttackingPoints(gameState);
 
   const userPrompt = buildUserPromptTemplate({
     playerId,
@@ -666,8 +627,8 @@ export function buildLLMUserPrompt(
     partnerId,
     trumpRank: trumpInfo.trumpRank,
     trumpSuit: trumpInfo.trumpSuit || "None",
-    isAttacking,
-    attackingPoints,
+    isAttacking: gameContext.isAttackingTeam,
+    attackingPoints: gameContext.currentPoints,
     historyStr,
     voidsStr,
     liveSuitPointsStr,

--- a/src/ai/llm/llmGamePrompt.ts
+++ b/src/ai/llm/llmGamePrompt.ts
@@ -5,7 +5,12 @@ import {
   getPartnerId,
   TrumpInfo,
   Suit,
+  Rank,
+  ComboType,
+  JokerType,
 } from "../../types";
+import { isComboUnbeatable } from "../../game/multiComboValidation";
+import { compareCards } from "../../game/cardComparison";
 import { sortCards } from "../../utils/cardSorting";
 import { analyzeSuitAvailability } from "../following/suitAvailabilityAnalysis";
 import { detectCandidateLeads } from "../leading/candidateLeadDetection";
@@ -191,6 +196,68 @@ ${allOptions || "- No candidates found (using fallback)"}
 }
 
 /**
+ * Renders a short, situation-specific "how to play this seat" bullet for the
+ * following path. STATIC_LLM_GAME_RULES §5/§6 state the general principles;
+ * this picks the one that actually applies to THIS seat, names the concrete
+ * players, and spells out the beat-back inference a small model would otherwise
+ * have to derive on its own. It scaffolds the LLM's judgement among the legal
+ * options — it does not choose the card.
+ */
+function localBuildSeatGuidance(g: {
+  isLast: boolean;
+  isTeammateWinning: boolean;
+  teammateWinSafe: boolean;
+  canBeatWinnerInSuit: boolean;
+  winningPlayerId: string;
+  winningCardStr: string;
+  oppListStr: string;
+  trickPoints: number;
+  isTrumpLead: boolean;
+  isAnyOpponentVoid: boolean;
+  isVoidScenario: boolean;
+}): string {
+  let bullet: string;
+
+  if (g.isVoidScenario) {
+    // Void in the led suit → ruff or sluff (§6).
+    if (g.isTeammateWinning && g.teammateWinSafe) {
+      bullet = `${g.winningPlayerId} (teammate) is winning safely — don't ruff over them; sluff a spare point card (10/K) to bank points for your team, else your lowest off-suit non-point.`;
+    } else if (g.isTeammateWinning) {
+      bullet = `${g.winningPlayerId} (teammate) leads but it isn't safe — sluff a low off-suit non-point; don't ruff over your own teammate.`;
+    } else if (g.trickPoints >= 10) {
+      bullet = `${g.winningPlayerId} (opponent) holds ${g.trickPoints} pts — ruff to win only if you can survive ${g.isLast ? "the rest (you're last)" : g.oppListStr}, sizing it to top a later void player; can't secure it → sluff low and keep your trump.`;
+    } else {
+      bullet = `Only ${g.trickPoints} pts and ${g.winningPlayerId} (opponent) leads — sluff your lowest off-suit non-point and conserve trump.`;
+    }
+  } else if (g.isTeammateWinning) {
+    // Following the led suit, teammate currently winning (§5.1 / §5.2).
+    bullet = g.teammateWinSafe
+      ? `${g.winningPlayerId} (teammate)'s win is safe — contribute points cheapest-first (10 > K > 5); don't play your own boss A/K (it wins nothing here) and never out-rank your teammate.`
+      : `${g.winningPlayerId} (teammate) leads but ${g.oppListStr} can still steal it — play a low non-point card of the led suit; don't commit points yet.`;
+  } else if (g.isLast) {
+    // Opponent winning, you act last with full info (§5.3 / §9 4th).
+    bullet = `You play last with full info — beat ${g.winningPlayerId}'s ${g.winningCardStr} with your cheapest sufficient card if you can; otherwise dump your lowest non-point (never a 5/10/K into an opponent's trick).`;
+  } else if (g.trickPoints >= 10) {
+    // Opponent winning, rich trick, players still behind you (§5.3).
+    if (!g.canBeatWinnerInSuit) {
+      bullet = `${g.trickPoints} pts at stake but you hold nothing that beats ${g.winningPlayerId}'s ${g.winningCardStr} here — duck low and keep your points/high cards for a trick you can win.`;
+    } else {
+      const caveat = g.isTrumpLead
+        ? "a regular trump K/10 loses to active ranks/jokers, so commit only a truly unbeatable trump — else duck low"
+        : g.isAnyOpponentVoid
+          ? "a void opponent can ruff, so even the suit boss may be cut — weigh ducking"
+          : "only the suit boss survives the players behind you; a mid card can be over-taken — else duck";
+      bullet = `${g.trickPoints} pts at stake and ${g.oppListStr} act after you — fight only with a card they can't beat back: ${caveat}.`;
+    }
+  } else {
+    // Opponent winning, thin trick (§5.4).
+    bullet = `Only ${g.trickPoints} pts and ${g.oppListStr} still to act — duck low and conserve; don't spend a boss or trump on a thin trick.`;
+  }
+
+  return `- ${bullet}`;
+}
+
+/**
  * Helper to build trick context and scenario analysis when following.
  */
 function localBuildFollowingPromptContext(
@@ -203,6 +270,7 @@ function localBuildFollowingPromptContext(
   activeTrickStatusStr: string;
   taskInstructionStr: string;
   suitAnalysisStr: string;
+  seatGuidanceStr: string;
 } {
   const currentTrick = gameState.currentTrick;
   if (!currentTrick || currentTrick.plays.length === 0) {
@@ -210,6 +278,7 @@ function localBuildFollowingPromptContext(
       activeTrickStatusStr: "",
       taskInstructionStr: "",
       suitAnalysisStr: "",
+      seatGuidanceStr: "",
     };
   }
 
@@ -250,38 +319,82 @@ function localBuildFollowingPromptContext(
 
   const winningPlay = plays.find((p) => p.playerId === winningPlayerId);
   const winningCard = winningPlay?.cards[0] || null;
+  const winningCardStr = winningCard ? winningCard.toString() : "their card";
 
+  // Cards already played this round plus those on the table — the memory used
+  // for unbeatable detection. The current player's own hand is passed separately.
+  const playedAndTable: Card[] = [
+    ...gameState.tricks.flatMap((t) => t.plays.flatMap((pl) => pl.cards)),
+    ...plays.flatMap((pl) => pl.cards),
+  ];
+
+  // "Boss" is an OFF-SUIT notion only: the highest card still live in a side
+  // suit, beatable only by a ruff. Memory-aware via isComboUnbeatable — a K
+  // becomes boss once both Aces are gone. (isComboUnbeatable returns false for
+  // trump, so this is naturally off-suit only.)
+  const winnerOffSuitBoss =
+    !!winningCard &&
+    !winningCard.isTrump(trumpInfo) &&
+    isComboUnbeatable(
+      { type: ComboType.Single, cards: [winningCard], value: 0 },
+      winningCard.suit,
+      playedAndTable,
+      handCards,
+      trumpInfo,
+      [],
+    );
+
+  // The trump group has no "boss"; only the Big Joker is guaranteed unbeatable
+  // (conservative — other high trumps are covered by the all-void check below).
+  const winnerTopTrump = !!winningCard && winningCard.joker === JokerType.Big;
+
+  // Can THIS player beat the current winner with a same-group card in hand?
+  const canBeatWinnerInSuit =
+    !!winningCard &&
+    handCards.some((c) => {
+      const sameGroup = winningCard.isTrump(trumpInfo)
+        ? c.isTrump(trumpInfo)
+        : !c.isTrump(trumpInfo) && c.suit === winningCard.suit;
+      return sameGroup && compareCards(c, winningCard, trumpInfo) > 0;
+    });
+
+  // All remaining opponents are confirmed void in the led suit/trump group.
+  const allRemainingOpponentsVoidLed =
+    remainingOpponents.length > 0 &&
+    remainingOpponents.every((oppId) => (voids[oppId] || []).includes(ledSuit));
+
+  // Teammate's win is "safe" when no opponents remain; their card is an off-suit
+  // boss the remaining (non-void) opponents can't top; they hold the top trump;
+  // or it is a trump trick and every remaining opponent is out of trump. An
+  // opponent void in an OFF-suit lead is NOT safe — they can ruff.
+  const teammateWinSafe =
+    isTeammateWinning &&
+    (remainingOpponents.length === 0 ||
+      (winnerOffSuitBoss && !isAnyOpponentVoid) ||
+      winnerTopTrump ||
+      (isTrumpLead && allRemainingOpponentsVoidLed));
+
+  const oppListStr = remainingOpponents.join(" and ");
   let winSecurityStr = "";
   if (isTeammateWinning) {
     if (remainingOpponents.length === 0) {
       winSecurityStr = `SECURED WIN: Your teammate (${winningPlayerId}) is winning, and there are NO opponents left to act. Your team is guaranteed to win this trick.`;
+    } else if (teammateWinSafe) {
+      const why =
+        winnerOffSuitBoss && !isAnyOpponentVoid
+          ? `with a card (${winningCardStr}) no remaining opponent can beat`
+          : winnerTopTrump
+            ? `with the top trump (${winningCardStr})`
+            : `a trump trick while the remaining opponents are out of trump`;
+      winSecurityStr = `LIKELY WIN: Your teammate (${winningPlayerId}) is winning ${why}. They are extremely likely to win this trick.`;
     } else {
-      // Check if teammate's winning card is a dominant boss card and opponents cannot trump it
-      let isBossCard = false;
-      let winningCardStr = "";
-      if (winningCard) {
-        winningCardStr = winningCard.toString();
-        if (winningCard.isTrump(trumpInfo)) {
-          isBossCard =
-            winningCard.joker !== undefined ||
-            winningCard.rank === trumpInfo.trumpRank;
-        } else {
-          const offSuitBossRank = trumpInfo.trumpRank === "A" ? "K" : "A";
-          isBossCard = winningCard.rank === offSuitBossRank;
-        }
-      }
-
-      if (isBossCard && !isAnyOpponentVoid) {
-        winSecurityStr = `LIKELY WIN: Your teammate (${winningPlayerId}) is winning with a dominant card (${winningCardStr}) and remaining opponents must follow suit (none are void). They are extremely likely to win this trick.`;
-      } else {
-        const oppList = remainingOpponents.join(" and ");
-        winSecurityStr = `UNCERTAIN: Your teammate (${winningPlayerId}) is winning, but opponent(s) [${oppList}] have yet to play. Since the lead is not a guaranteed boss card or opponents might be void/hold higher cards, the outcome is uncertain.`;
-      }
+      winSecurityStr = `UNCERTAIN: Your teammate (${winningPlayerId}) is winning, but opponent(s) [${oppListStr}] have yet to play — the card is beatable or an opponent may be void / hold higher, so the outcome is uncertain.`;
     }
   } else {
     winSecurityStr = `UNCERTAIN: Opponent (${winningPlayerId}) is currently winning the trick.`;
   }
 
+  const isLast = yetToPlay.length === 0;
   const seatLabel =
     ["1st (leader)", "2nd", "3rd", "4th"][plays.length] ||
     `${plays.length + 1}th`;
@@ -366,10 +479,25 @@ function localBuildFollowingPromptContext(
 
   const suitAnalysisStr = lines.join("\n") + "\n";
 
+  const seatGuidanceStr = localBuildSeatGuidance({
+    isLast,
+    isTeammateWinning,
+    teammateWinSafe,
+    canBeatWinnerInSuit,
+    winningPlayerId,
+    winningCardStr,
+    oppListStr,
+    trickPoints,
+    isTrumpLead,
+    isAnyOpponentVoid,
+    isVoidScenario: analysis.scenario === "void",
+  });
+
   return {
     activeTrickStatusStr,
     taskInstructionStr,
     suitAnalysisStr,
+    seatGuidanceStr,
   };
 }
 
@@ -409,6 +537,42 @@ function localFormatPlayerVoids(
         `- ${pId}: ${suitsList.length > 0 ? suitsList.join(", ") : "None yet"}`,
     )
     .join("\n");
+}
+
+/**
+ * Sums the point-card value still unseen in each non-trump suit — points not
+ * yet played and not in this player's hand, so they sit in another hand or the
+ * hidden kitty. Counts both deck copies (50 pts/suit: 2×5 + 2×10 + 2×K, minus
+ * any point rank the trump rank promotes into the trump group). A reference
+ * upper bound on what the suit can still yield, not an exact figure.
+ */
+function localFormatLiveOffSuitPoints(
+  gameState: GameState,
+  handCards: Card[],
+): string {
+  const { trumpInfo } = gameState;
+
+  let suitTotal = 50;
+  if (trumpInfo.trumpRank === Rank.Five) suitTotal -= 10;
+  else if (trumpInfo.trumpRank === Rank.Ten) suitTotal -= 20;
+  else if (trumpInfo.trumpRank === Rank.King) suitTotal -= 20;
+
+  // Every card this player can already account for (played + on table + hand).
+  const seen: Card[] = [
+    ...gameState.tricks.flatMap((t) => t.plays.flatMap((pl) => pl.cards)),
+    ...(gameState.currentTrick?.plays.flatMap((pl) => pl.cards) ?? []),
+    ...handCards,
+  ];
+
+  const parts = [Suit.Spades, Suit.Hearts, Suit.Clubs, Suit.Diamonds]
+    .filter((suit) => suit !== trumpInfo.trumpSuit)
+    .map((suit) => {
+      const seenPts = seen
+        .filter((c) => !c.isTrump(trumpInfo) && c.suit === suit)
+        .reduce((sum, c) => sum + c.points, 0);
+      return `${suit} ${Math.max(0, suitTotal - seenPts)}`;
+    });
+  return parts.join(" · ");
 }
 
 /**
@@ -454,6 +618,7 @@ export function buildLLMUserPrompt(
   let taskInstructionStr = "";
   let candidateOptionsStr = "";
   let suitAnalysisStr = "";
+  let seatGuidanceStr = "";
 
   if (isLeading) {
     const context = localBuildLeadingPromptContext(
@@ -477,6 +642,7 @@ export function buildLLMUserPrompt(
     activeTrickStatusStr = context.activeTrickStatusStr;
     taskInstructionStr = context.taskInstructionStr;
     suitAnalysisStr = context.suitAnalysisStr;
+    seatGuidanceStr = context.seatGuidanceStr;
   }
 
   // Reconstruct round tricks history (limit to last 3 tricks to keep prompt light)
@@ -484,6 +650,9 @@ export function buildLLMUserPrompt(
 
   // Detect suit voids per player from round trick history
   const voidsStr = localFormatPlayerVoids(gameState, trumpInfo);
+
+  // Point cards still unseen in each off-suit (others' hands or hidden kitty)
+  const liveSuitPointsStr = localFormatLiveOffSuitPoints(gameState, handCards);
 
   const currentPlayer = gameState.players.find((p) => p.id === playerId);
   const teamId = currentPlayer?.team || "A";
@@ -501,12 +670,14 @@ export function buildLLMUserPrompt(
     attackingPoints,
     historyStr,
     voidsStr,
+    liveSuitPointsStr,
     activeTrickStatusStr,
     handCardsCount: handCards.length,
     handChoicesStr,
     isLeading,
     candidateOptionsStr,
     suitAnalysisStr,
+    seatGuidanceStr,
     taskInstructionStr,
   });
 

--- a/src/ai/llm/llmPromptTemplates.ts
+++ b/src/ai/llm/llmPromptTemplates.ts
@@ -1,6 +1,6 @@
 export const STATIC_LLM_GAME_RULES = `# Shengji / Tractor — Trick-Play Decision Guide
 
-You are an expert Tractor player making ONE play at a genuinely close decision. Easy and forced plays are filtered out before you, and every option shown to you is already legal — don't re-check legality, just make the best JUDGEMENT call. Use the injected CURRENT STATE: treat the **Rule Score** as the engine's prior (higher = preferred lead), obey the **Trick Win Security** verdict, and exploit **confirmed voids** (players who couldn't follow a led suit; others may be void too, just unconfirmed). Output JSON only: {"reasoning":"<one sentence>","play":["3♣","3♣"]} — name cards by the exact notation shown in YOUR HAND.
+You are an expert Tractor player making ONE play at a genuinely close decision. Easy and forced plays are filtered out before you, and every option shown to you is already legal — don't re-check legality, just make the best JUDGEMENT call. Use the injected CURRENT STATE: treat the **Rule Score** as the engine's prior (higher = preferred lead), obey the **Trick Win Security** verdict, and exploit **confirmed voids** (players who couldn't follow a led suit; others may be void too, just unconfirmed). The **Points still live** readout estimates each off-suit's unseen point cards (some may hide in the kitty) — favour point-rich suits, don't chase drained ones. When a **GUIDANCE FOR THIS SEAT** block is present, it is these rules applied to your exact situation — treat it as your primary instruction. Output JSON only: {"reasoning":"<one sentence>","play":["3♣","3♣"]} — name cards by the exact notation shown in YOUR HAND.
 
 ## 1. Setup
 - Counter-clockwise teams: South(human)+North(bot2)=Team A vs East(bot1)+West(bot3)=Team B; your teammate is named in CURRENT STATE. Trick order: Leader → 2nd → 3rd → 4th (4th has perfect info).
@@ -10,7 +10,7 @@ You are an expert Tractor player making ONE play at a genuinely close decision. 
 - Trump group is ONE combined suit: Big Joker > Small Joker > trump-rank in trump suit > trump-rank in other suits (all EQUAL; first played wins) > trump-suit regulars (A>K>…>3).
 - **Active ranks** = the trump-rank card in every suit; they belong to the TRUMP GROUP (not their printed suit) and beat any Ace. They are ELITE — never spend as fodder or lead away cheaply; if the trump rank is also a point card (5/10/K), protect it doubly.
 - Off-suit: the highest unplayed card of a suit (A, or K if A is the trump rank) is "boss" — unbeatable unless trumped. Cross-suit cards can't beat each other; only trump beats off-suit.
-- No-Trump round: trump = jokers + the four active ranks only (no trump regulars) → trump is extremely scarce; hoard it and treat off-suit bosses as near-untouchable.
+- No-Trump round: trump = jokers + the four active ranks only (no trump regulars) → trump is scarce; hoard it, off-suit bosses near-untouchable.
 
 ## 3. Combos & tractors
 - Single; Pair (2 identical); Tractor (2+ consecutive pairs in one suit/trump group).
@@ -23,15 +23,15 @@ You are an expert Tractor player making ONE play at a genuinely close decision. 
 - A pair needs a pair, a tractor needs a tractor (two singles can't beat a pair). Exhaust pairs before singles.
 
 ## 5. Following — decision order (stop at first match)
-1. **Teammate winning AND safe** (Security = SECURED/LIKELY, you're 4th, the next opponent is void in the led suit/trump, OR teammate led an off-suit boss A early — suits rarely void yet, so it likely holds even if Security says UNCERTAIN): CONTRIBUTE points with your cheapest cards — feed 10 first, then K, then 5 (give the 10, keep the stronger K; your own boss A/K wins nothing here, so it's better saved for your own trick). Cheap trump is fine when void. NEVER out-rank or over-trump your teammate's own winning card.
+1. **Teammate winning AND safe** (Trick Win Security = SECURED/LIKELY): CONTRIBUTE points cheapest-first — feed 10, then K, then 5 (give the 10, keep the stronger K; your own boss A/K wins nothing here, so save it for your own trick). Cheap trump is fine when void. NEVER out-rank or over-trump your teammate's own winning card.
 2. **Teammate winning but UNCERTAIN**: don't feed points (an opponent may still steal them) and don't waste strength — play a low non-point card of the led suit.
-3. **Opponent winning, ≥10 pts on table**: fight for it — scale your card to the stakes. Big points justify a boss/high trump; as an early follower commit a card later players can't beat back, don't lose a rich trick cheaply. (4th player: cheapest sufficient card.) Ruff if void and worthwhile. Can't win → step 5.
+3. **Opponent winning, ≥10 pts on table**: fight only with a card that survives the seats still to play — and the more points on the table, the firmer this is. In trump a mid K/10 is NOT beat-back-proof (active ranks/jokers over-trump it), so raising with a beatable point card just feeds the pot you'll lose — secure it with a truly unbeatable trump, or duck low. Ruff if void and worthwhile. Can't win → step 5.
 4. **Opponent winning, <10 pts**: duck — play low, conserve. Don't spend a boss/trump on a near-empty trick.
 5. **Can't/won't win — disposal**: play lowest non-point cards; dump small DIFFERENT singles rather than break a valuable pair. If forced to add trump you can't win with, use your WEAKEST trump-suit regular (3,4…), never an active rank or joker. NEVER discard 5/10/K into an opponent's trick.
 
 ## 6. Ruffing when void
 - Ruff only to secure a worthwhile trick (≥10 pts) or block opponents; otherwise conserve trump (especially No-Trump) — when void and not ruffing, lean toward shedding loose off-suit non-points over trump (even a low trump can ruff later), but a lone low trump is usually worth less than an off-suit pair/tractor or a live boss A (suit not yet void), so letting it go to keep those is often the better trade.
-- Size the ruff to the stakes and who's left: to win a rich trick, ruff high enough to survive a later void player's over-ruff — not a bare-minimum trump that gets topped (when last, or points are small, the lowest sufficient trump is enough). If a later void player out-ruffs you regardless, don't burn a high trump — use an intermediate/point trump to force a bigger one.
+- Size the ruff to who's left: to win a rich trick, ruff high enough to survive a later void player's over-ruff, not a bare minimum that gets topped (when last or points are small, the lowest sufficient trump is enough). If you'll be out-ruffed regardless, don't burn a high trump — use a point/intermediate trump to force a bigger one.
 - Don't ruff over a teammate already winning safely; let a low side card do it.
 
 ## 7. Multi-combo
@@ -47,9 +47,9 @@ Trust the Rule Score ordering; deviate only with a clear reason. Among close opt
 Never lead a lone active rank or joker — premium control you keep.
 
 ## 9. Position cues
-- 2nd: partial info; teammate (4th) can cover. Grab now only with a clear boss when points are up; else play low.
-- 3rd: blocking seat. Back a strong teammate by feeding points; force/block to protect a weak teammate or to beat an opponent — never over-trump your teammate.
-- 4th: perfect info. Teammate winning → feed (10>K>5). Opponent winning → take with the cheapest sufficient card, else dump lowest non-point.
+- 2nd: partial info; teammate (4th) can still cover, so commit early only with a clear boss when points are up.
+- 3rd: blocking seat; back a strong teammate or force/block a weak one — but any block must survive the 4th seat, and never over-trump your teammate.
+- 4th: perfect info; act precisely to the trick with no waste.
 
 Conservation through-line: keep top trump (jokers, active ranks, high pairs) and off-suit bosses for moments that matter — winning big-point tricks, blocking, guaranteed leads. Spend the cheapest non-point card when a play won't win or help your teammate.
 `;
@@ -64,12 +64,14 @@ export interface UserPromptTemplateArgs {
   attackingPoints: number;
   historyStr: string;
   voidsStr: string;
+  liveSuitPointsStr: string;
   activeTrickStatusStr: string;
   handCardsCount: number;
   handChoicesStr: string;
   isLeading: boolean;
   candidateOptionsStr: string;
   suitAnalysisStr: string;
+  seatGuidanceStr: string;
   taskInstructionStr: string;
 }
 
@@ -82,6 +84,7 @@ export function buildUserPromptTemplate(args: UserPromptTemplateArgs): string {
 - Role: ${args.isAttacking ? "ATTACKING (capture 80+ pts to win the round)" : "DEFENDING (hold attackers under 80 pts)"}
 - Attackers have captured ${args.attackingPoints} / 80 pts so far
 - Trump: rank ${args.trumpRank}, suit ${args.trumpSuit}
+- Points still live in off-suits (in others' hands or the hidden kitty — reference, not exact): ${args.liveSuitPointsStr}
 
 === RECENT TRICKS ===
 ${args.historyStr}
@@ -91,7 +94,7 @@ ${args.voidsStr}
 
 === ACTIVE TRICK ===
 ${args.activeTrickStatusStr}
-
+${args.seatGuidanceStr ? `\n=== GUIDANCE FOR THIS SEAT (the rules applied to your exact situation — your primary instruction) ===\n${args.seatGuidanceStr}\n` : ""}
 === YOUR HAND (grouped by suit, strongest → weakest) ===
 ${args.handCardsCount} cards in hand:
 


### PR DESCRIPTION
This PR implements a programmatic dynamic seat-guidance layer to the LLM following prompt and integrates it with the core engine's memory context.

### Key Changes:
1. **Dynamic Seat Guidance (`localBuildSeatGuidance`):**
   - Generates a highly specialized strategic directive for the LLM based on seat, teammate winning safety (SECURED/LIKELY/UNCERTAIN), points at stake, and suit void status.
   - Instructs the LLM to treat this section as its primary instruction, reducing reasoning complexity for smaller models.
2. **Single-Source Memory Context Integration:**
   - Integrates engine's `MemoryContext` to retrieve player voids dynamically, eliminating the need to parse historical tricks on-the-fly.
   - Uses `isComboUnbeatable` from the engine to check if a teammate's currently winning card is an off-suit boss.
3. **Live Points Tracker (`localFormatLiveOffSuitPoints`):**
   - Estimates outstanding points in each off-suit still in other players' hands or the hidden kitty, guiding the LLM's card selection.
4. **Prompt & Skill Documentation Update:**
   - Refines `STATIC_LLM_GAME_RULES` for better consistency and instructs the LLM on reading the seat-guidance section.
   - Updates `prompt-refinement/SKILL.md` to version `1.3.0` documenting this architecture.