### PR TITLE
Simplify and clean up Chinese game completion and declaration messages

### DIFF
--- a/src/locales/zh/modals.json
+++ b/src/locales/zh/modals.json
@@ -11,12 +11,12 @@
     "nextRound": "下一轮 ➤"
   },
   "roundResult": {
-    "attackingWonDefend": "{{teamName}}得{{points}}分上台，下轮由该队当庄打{{rank}}！",
-    "attackingWonAdvance": "{{teamName}}得{{points}}分上台，升{{advancement}}级，下轮当庄打{{rank}}！",
-    "attackingWonAce": "{{teamName}}得{{points}}分上台，达到A级！下轮必须守庄成功才能赢得游戏！",
-    "defendingWonGame": "{{teamName}}{{pointMessage}}，成功守庄并赢得整个游戏！",
-    "defendingWonAdvance": "{{teamName}}{{pointMessage}}，守庄成功，升{{advancement}}级，下轮打{{rank}}！",
-    "defendingWonAce": "{{teamName}}{{pointMessage}}，守庄成功，达到A级！下轮必须守庄成功才能赢得整个游戏！",
+    "attackingWonDefend": "{{teamName}}得{{points}}分上台，下轮打{{rank}}！",
+    "attackingWonAdvance": "{{teamName}}得{{points}}分上台，升{{advancement}}级打{{rank}}！",
+    "attackingWonAce": "{{teamName}}得{{points}}分上台，下轮打Ace，必须守住Ace才能赢得游戏！",
+    "defendingWonGame": "{{teamName}}{{pointMessage}}，成功守庄并赢得游戏！",
+    "defendingWonAdvance": "{{teamName}}{{pointMessage}}，升{{advancement}}级打{{rank}}！",
+    "defendingWonAce": "{{teamName}}{{pointMessage}}，下轮打Ace，必须守住Ace才能赢得游戏！",
     "heldToPoints": "将{{otherTeamName}}压制在0分（大光）",
     "defendedWithPoints": "将{{otherTeamName}}控制在{{points}}分",
     "kittyBonus": "抠底得分：{{kittyPoints}} x {{multiplier}}"

--- a/src/locales/zh/trumpDeclaration.json
+++ b/src/locales/zh/trumpDeclaration.json
@@ -12,7 +12,7 @@
   },
   "messages": {
     "currentDeclaration": "{{playerName}} 亮主：{{declaration}}",
-    "trumpDeclarationLabel": "已亮主牌：{{declaration}}，{{playerName}}",
+    "trumpDeclarationLabel": "已亮主牌：{{declaration}} {{playerName}}",
     "noDeclarations": "无人亮主",
     "noValidDeclarations": "当前手牌无有效亮主选项",
     "needMatchingCards": "需要级牌或双王来亮主/反主",


### PR DESCRIPTION
Streamlines the Chinese localization strings in `modals.json` and `trumpDeclaration.json`:

- Simplifies round result announcements, removing redundancies (e.g. "下轮由该队当庄" is implied by "上台"/"当庄").
- Restructures Ace level targets to be clearer: "必须守住Ace才能赢得整个游戏" is refined and consistent.
- Cleans up formatting issues, removing the awkward comma separation in the current declaration labels.