### PR TITLE
Refine LLM prompt 4th player strategy and teammate point contribution

### DIFF
--- a/src/ai/llm/llmGamePrompt.ts
+++ b/src/ai/llm/llmGamePrompt.ts
@@ -207,11 +207,11 @@ function localBuildSeatGuidance(g: {
   } else if (g.isTeammateWinning) {
     // Following the led suit, teammate currently winning (§5.1 / §5.2).
     bullet = g.teammateWinSafe
-      ? `${g.winningPlayerId} (teammate)'s win is safe — bank your biggest spare points, giving 10s and Ks freely (card rank is moot once the win is locked); hold back only a live boss A/K you can cash on your own trick, and never out-rank your teammate.`
+      ? `${g.winningPlayerId} (teammate)'s win is safe — bank your biggest spare points, giving 10s and Ks freely (do not worry if playing points out-ranks your teammate's card, as your team still takes the trick); hold back only a live boss A/K you can cash on your own trick.`
       : `${g.winningPlayerId} (teammate) leads but ${g.oppListStr} can still steal it — play a low non-point card of the led suit; don't commit points yet.`;
   } else if (g.isLast) {
     // Opponent winning, you act last with full info (§5.3 / §9 4th).
-    bullet = `You play last with full info — beat ${g.winningPlayerId}'s ${g.winningCardStr} with your cheapest sufficient card if you can; otherwise dump your lowest non-point (never a 5/10/K into an opponent's trick).`;
+    bullet = `You play last with full info — beat ${g.winningPlayerId}'s ${g.winningCardStr} with your cheapest sufficient card if you can (prefer winning if you hold points that can win or the trick contains points; never conserve off-suit cards); otherwise dump your lowest non-point (never a 5/10/K into an opponent's trick).`;
   } else if (g.trickPoints >= 10) {
     // Opponent winning, rich trick, players still behind you (§5.3).
     if (!g.canBeatWinnerInSuit) {
@@ -226,7 +226,7 @@ function localBuildSeatGuidance(g: {
     }
   } else {
     // Opponent winning, thin trick (§5.4).
-    bullet = `Only ${g.trickPoints} pts and ${g.oppListStr} still to act — duck low and conserve; don't spend a boss or trump on a thin trick.`;
+    bullet = `Only ${g.trickPoints} pts and ${g.oppListStr} still to act — if off-suit, play your boss/highest to win the trick and secure the lead; if trump, duck low and conserve.`;
   }
 
   return `- ${bullet}`;

--- a/src/ai/llm/llmPromptTemplates.ts
+++ b/src/ai/llm/llmPromptTemplates.ts
@@ -26,14 +26,14 @@ Trust the **Rule Score** ordering as your baseline, cashing bosses first and ble
 - **Absolute Laws**: Follow the led suit/trump group if you hold it. You must match the led combo structure — obey the requirements in **## Suit-Following Analysis** (provided in the prompt below). If you do not hold matching combos (e.g. you hold only singles under a pair lead), follow with singles instead. NEVER split pairs when matching combos are held, and NEVER play or duplicate cards that are not explicitly shown in your hand list — you cannot play a pair or repeat a card's notation unless you hold multiple copies of that card (shown multiple times in your hand/available cards). If a multi-combo is led, match the combo structure and total length.
 - **Seat Guidance**: Obey the situation-specific bullet under **## Seat Guidance** (provided in the prompt below) as your primary instruction. It dynamically tells you when to duck low, bank points on a safe teammate's trick, ruff/sluff, or conserve your elite cards.
 - **Ruffing & Sluffing (Void)**: Ruff only to secure a worthwhile trick (≥10 pts) or block opponents. Size your ruff high enough to survive later players' over-ruffs; if you'll be out-ruffed regardless, use a low card to sluff instead of wasting trump. Never ruff over a teammate who is winning safely.
-- **Conserve Control**: Keep your high trumps and off-suit bosses for tricks you lead or can absolutely win. Spend your cheapest non-point cards on lost tricks.
+- **Conserve Control**: Hoard high trumps for key wins/blocks. Do NOT conserve off-suit cards; play off-suit bosses/highest cards to win tricks, preventing opponents from escaping points and enabling teammates to contribute points safely. When your teammate is winning safely, play points (5/10/K) freely even if doing so out-ranks your teammate's card.
 
 ## 6. Position Cues
 - **2nd Seat**: Commit early only with a clear boss when points are up. Teammate (4th) can still cover.
 - **3rd Seat**: Back a strong teammate or block an opponent, but ensure your play survives the 4th seat. Never over-trump your teammate.
-- **4th Seat**: Perfect information. Act precisely to win the trick or dump trash with zero waste.
+- **4th Seat**: Perfect information. Win with the cheapest sufficient card if you can. Prefer winning if you hold points that can win or the trick contains points; otherwise dump your lowest non-point. Never conserve off-suit cards.
 
-Conservation through-line: Keep top trumps and off-suit bosses for moments that matter (winning big tricks, blocking, guaranteed leads). Dump cheap non-point cards when you cannot win.
+Conservation: Hoard top trumps for key wins/blocks. Do not conserve off-suit cards; use them to win tricks and secure the lead.
 `;
 
 export interface UserPromptTemplateArgs {


### PR DESCRIPTION
Refined 4th seat prompt rules to prioritize winning if the player holds point cards that can win or if the trick contains points, regardless of whether it is a trump or off-suit card. Also clarified that when a teammate is winning safely, the player should play points freely even if it out-ranks the teammate's winning card, and updated dynamic seat guidance/conservation rules accordingly.