### PR TITLE
Single-click verify and save in AIConfigModal

### DIFF
--- a/src/components/AIConfigModal.tsx
+++ b/src/components/AIConfigModal.tsx
@@ -68,9 +68,19 @@ const AIConfigModal: React.FC<AIConfigModalProps> = ({
     setConnectionStatus({ kind: "idle" });
   }, []);
 
-  // ── Connection test ────────────────────────────────────────────────────────
+  // ── Save & Verify ──────────────────────────────────────────────────────────
 
-  const handleTestConnection = useCallback(async () => {
+  const handleSave = useCallback(async () => {
+    if (!useLLM) {
+      onSave({
+        ...DEFAULT_LLM_CONFIG,
+        enabled: false,
+        apiKey: apiKey.trim(),
+        model: selectedModel,
+      });
+      return;
+    }
+
     if (!apiKey.trim()) {
       setConnectionStatus({
         kind: "error",
@@ -87,52 +97,29 @@ const AIConfigModal: React.FC<AIConfigModalProps> = ({
       DEFAULT_LLM_CONFIG.apiUrl,
     );
 
-    setConnectionStatus(
-      result.success
-        ? {
-            kind: "success",
-            message: t("aiConfig.llm.connectedMsg", {
-              modelName:
-                MODELS.find((m) => m.id === selectedModel)?.name ??
-                selectedModel,
-            }),
-          }
-        : {
-            kind: "error",
-            message: t("aiConfig.llm.connectionError", {
-              error: result.message,
-            }),
-          },
-    );
-  }, [apiKey, selectedModel, t]);
-
-  // ── Save ───────────────────────────────────────────────────────────────────
-
-  const handleSave = useCallback(() => {
-    const newConfig: LLMConfig = {
-      ...DEFAULT_LLM_CONFIG,
-      enabled: useLLM,
-      apiKey: apiKey.trim(),
-      model: selectedModel,
-    };
-    onSave(newConfig);
-  }, [useLLM, apiKey, selectedModel, onSave]);
-
-  // ── Test & Save (merged action) ────────────────────────────────────────────
-
-  const handleTestAndSave = useCallback(async () => {
-    if (!useLLM) {
-      handleSave();
-      return;
+    if (result.success) {
+      setConnectionStatus({
+        kind: "success",
+        message: t("aiConfig.llm.connectedMsg", {
+          modelName:
+            MODELS.find((m) => m.id === selectedModel)?.name ?? selectedModel,
+        }),
+      });
+      onSave({
+        ...DEFAULT_LLM_CONFIG,
+        enabled: true,
+        apiKey: apiKey.trim(),
+        model: selectedModel,
+      });
+    } else {
+      setConnectionStatus({
+        kind: "error",
+        message: t("aiConfig.llm.connectionError", {
+          error: result.message,
+        }),
+      });
     }
-    if (connectionStatus.kind === "success") {
-      // Already tested — save directly
-      handleSave();
-      return;
-    }
-    // First press: run the test; button will become "Save" on success
-    await handleTestConnection();
-  }, [useLLM, connectionStatus.kind, handleTestConnection, handleSave]);
+  }, [useLLM, apiKey, selectedModel, onSave, t]);
 
   // ── Render ─────────────────────────────────────────────────────────────────
 
@@ -385,7 +372,7 @@ const AIConfigModal: React.FC<AIConfigModalProps> = ({
                 styles.saveBtn,
                 connectionStatus.kind === "testing" && styles.saveBtnDisabled,
               ]}
-              onPress={handleTestAndSave}
+              onPress={handleSave}
               disabled={connectionStatus.kind === "testing"}
               activeOpacity={0.8}
             >
@@ -393,8 +380,8 @@ const AIConfigModal: React.FC<AIConfigModalProps> = ({
                 <ActivityIndicator size="small" color="#fff" />
               ) : (
                 <Text style={styles.saveBtnText}>
-                  {useLLM && connectionStatus.kind !== "success"
-                    ? t("aiConfig.buttons.verify")
+                  {useLLM
+                    ? t("aiConfig.buttons.verifyAndSave")
                     : t("aiConfig.buttons.save")}
                 </Text>
               )}

--- a/src/locales/en/modals.json
+++ b/src/locales/en/modals.json
@@ -58,7 +58,6 @@
     },
     "buttons": {
       "cancel": "Cancel",
-      "verify": "Verify",
       "verifyAndSave": "Verify & Save",
       "save": "Save"
     },

--- a/src/locales/en/modals.json
+++ b/src/locales/en/modals.json
@@ -59,6 +59,7 @@
     "buttons": {
       "cancel": "Cancel",
       "verify": "Verify",
+      "verifyAndSave": "Verify & Save",
       "save": "Save"
     },
     "models": {

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -149,6 +149,7 @@ export interface ModalsTranslations {
     buttons: {
       cancel: string;
       verify: string;
+      verifyAndSave: string;
       save: string;
     };
     models: {

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -148,7 +148,6 @@ export interface ModalsTranslations {
     };
     buttons: {
       cancel: string;
-      verify: string;
       verifyAndSave: string;
       save: string;
     };

--- a/src/locales/zh/modals.json
+++ b/src/locales/zh/modals.json
@@ -58,7 +58,6 @@
     },
     "buttons": {
       "cancel": "取消",
-      "verify": "验证",
       "verifyAndSave": "验证并保存",
       "save": "保存"
     },

--- a/src/locales/zh/modals.json
+++ b/src/locales/zh/modals.json
@@ -59,6 +59,7 @@
     "buttons": {
       "cancel": "取消",
       "verify": "验证",
+      "verifyAndSave": "验证并保存",
       "save": "保存"
     },
     "models": {


### PR DESCRIPTION
Merge the verify and save actions into a single click flow that automatically saves on success and waits on failure. Cleans up the unused 'verify' translation key.