### PR TITLE
feat(llm): simplify model config to Default + custom OpenRouter id

### DIFF
--- a/src/ai/llm/llmAIStrategy.ts
+++ b/src/ai/llm/llmAIStrategy.ts
@@ -2,6 +2,7 @@ import { Card, GameState, PlayerId } from "../../types";
 import { gameLogger } from "../../utils/gameLogger";
 import { getLLMConfig, isLLMEnabled } from "./llmConfig";
 import { callOpenRouter, ChatMessage } from "./llmAIClient";
+import { resolveOpenRouterModelId } from "./llmModels";
 import { buildLLMUserPrompt } from "./llmGamePrompt";
 import { getPlayValidationError } from "../../game/playValidation";
 
@@ -165,7 +166,7 @@ export async function callLLMForDecision(
       // Call LLM API
       const responseText = await callOpenRouter(
         config.apiKey,
-        config.model,
+        resolveOpenRouterModelId(config.model),
         config.apiUrl,
         messages,
         config.timeoutMs,

--- a/src/ai/llm/llmConfig.ts
+++ b/src/ai/llm/llmConfig.ts
@@ -1,8 +1,8 @@
 import { gameLogger } from "../../utils/gameLogger";
 import {
   DEFAULT_API_URL,
-  DEFAULT_MODEL_ID,
-  AVAILABLE_MODELS,
+  DEFAULT_MODEL_SENTINEL,
+  isDefaultModelSelection,
 } from "./llmModels";
 
 export interface LLMConfig {
@@ -17,7 +17,7 @@ export interface LLMConfig {
 export const DEFAULT_LLM_CONFIG: LLMConfig = {
   enabled: false,
   apiKey: "",
-  model: DEFAULT_MODEL_ID,
+  model: DEFAULT_MODEL_SENTINEL,
   apiUrl: DEFAULT_API_URL,
   timeoutMs: 15000,
   applyToPlayers: ["bot1", "bot2", "bot3"],
@@ -34,14 +34,16 @@ export function getLLMConfig(): LLMConfig {
       const stored = localStorage.getItem("tractor_llm_config");
       if (stored) {
         const savedConfig = JSON.parse(stored) as Partial<LLMConfig>;
-        const savedModel = savedConfig.model || DEFAULT_LLM_CONFIG.model;
-        const isValidModel =
-          AVAILABLE_MODELS.some((m) => m.id === savedModel) ||
-          process.env.NODE_ENV === "test";
+        const rawModel = savedConfig.model ?? "";
+        // Default sentinel + legacy concrete default id normalize to sentinel;
+        // any other non-empty id is preserved as a user-supplied OpenRouter id.
+        const model = isDefaultModelSelection(rawModel)
+          ? DEFAULT_MODEL_SENTINEL
+          : rawModel.trim();
         return {
           enabled: savedConfig.enabled ?? DEFAULT_LLM_CONFIG.enabled,
           apiKey: savedConfig.apiKey ?? DEFAULT_LLM_CONFIG.apiKey,
-          model: isValidModel ? savedModel : DEFAULT_LLM_CONFIG.model,
+          model,
           apiUrl: savedConfig.apiUrl || DEFAULT_LLM_CONFIG.apiUrl,
           timeoutMs: savedConfig.timeoutMs || DEFAULT_LLM_CONFIG.timeoutMs,
           applyToPlayers:

--- a/src/ai/llm/llmModels.ts
+++ b/src/ai/llm/llmModels.ts
@@ -1,60 +1,70 @@
-export interface ModelInfo {
+/**
+ * Sentinel stored in LLM config when the user selects the built-in Default model.
+ * Resolved to {@link DEFAULT_MODEL.id} only at call/verify time, so the default
+ * model id can change later without migrating saved configs.
+ */
+export const DEFAULT_MODEL_SENTINEL = "default";
+
+export interface DefaultModelInfo {
   id: string;
-  name: string;
-  icon: string;
-  rank: string;
-  rankColor: string;
+  displayName: string;
   inputPrice: string;
   outputPrice: string;
-  description: string;
 }
 
-export const AVAILABLE_MODELS: ModelInfo[] = [
-  {
-    id: "google/gemini-3.1-flash-lite",
-    name: "Gemini 3.1 Flash Lite",
-    icon: "✨",
-    rank: "Best Overall (Recommended)",
-    rankColor: "#06B6D4",
-    inputPrice: "$0.25",
-    outputPrice: "$1.50",
-    description:
-      "Recommended. Speed Champion (~1-2s latency). Optimized for low-latency, high-volume workloads with improved strategic reasoning and outstanding rules compliance.",
-  },
-  {
-    id: "x-ai/grok-4.5",
-    name: "Grok 4.5",
-    icon: "👁️",
-    rank: "Elite Strategy & Reasoning",
-    rankColor: "#10B981",
-    inputPrice: "$2.00",
-    outputPrice: "$6.00",
-    description:
-      "State-of-the-art strategic and reasoning model from xAI. Outstanding tactical depth and card coordination.",
-  },
-  {
-    id: "deepseek/deepseek-v4-flash",
-    name: "DeepSeek V4 Flash",
-    icon: "🌊",
-    rank: "Peak Strategic Master",
-    rankColor: "#8B5CF6",
-    inputPrice: "$0.077",
-    outputPrice: "$0.154",
-    description:
-      "Strategic master. High strategic depth and excellent rules compliance, though latency can vary under load.",
-  },
-  {
-    id: "qwen/qwen3.6-flash",
-    name: "Qwen 3.6 Flash",
-    icon: "🔷",
-    rank: "Elite Strategy",
-    rankColor: "#00BCD4",
-    inputPrice: "$0.1875",
-    outputPrice: "$1.125",
-    description:
-      "Elite tactical engine. Flawless rules compliance, superb combo recognition, and great point preservation.",
-  },
-];
+/**
+ * The built-in Default model: id + display metadata kept cohesive so a model
+ * bump is a one-spot edit.
+ */
+export const DEFAULT_MODEL: DefaultModelInfo = {
+  id: "google/gemini-3.1-flash-lite",
+  displayName: "Gemini 3.1 Flash Lite",
+  inputPrice: "$0.25",
+  outputPrice: "$1.50",
+};
 
-export const DEFAULT_MODEL_ID = AVAILABLE_MODELS[0].id;
+/** Concrete OpenRouter model id backing the built-in Default selection. */
+export const DEFAULT_MODEL_ID = DEFAULT_MODEL.id;
+
 export const DEFAULT_API_URL = "https://openrouter.ai/api/v1/chat/completions";
+
+/** Trim a stored config model value (single normalization site). */
+function normalizeStoredModel(storedModel: string): string {
+  return storedModel.trim();
+}
+
+/**
+ * Map a stored config value to the concrete OpenRouter model id used in API
+ * calls. The sentinel and empty values resolve to the built-in default; any
+ * other non-empty string is treated as a user-supplied OpenRouter model id.
+ */
+export function resolveOpenRouterModelId(storedModel: string): string {
+  const trimmed = normalizeStoredModel(storedModel);
+  if (trimmed === "" || trimmed === DEFAULT_MODEL_SENTINEL) {
+    return DEFAULT_MODEL_ID;
+  }
+  return trimmed;
+}
+
+/**
+ * Whether the stored config value means "use the built-in Default model".
+ * Treats the legacy concrete default id as Default so old saves normalize to
+ * the sentinel on load.
+ */
+export function isDefaultModelSelection(storedModel: string): boolean {
+  const trimmed = normalizeStoredModel(storedModel);
+  return (
+    trimmed === "" ||
+    trimmed === DEFAULT_MODEL_SENTINEL ||
+    trimmed === DEFAULT_MODEL_ID
+  );
+}
+
+/**
+ * Whether a custom model id has the OpenRouter `provider/model` shape.
+ * Not an existence check — the connectivity test is the real validator.
+ */
+export function isValidOpenRouterModelId(modelId: string): boolean {
+  const trimmed = normalizeStoredModel(modelId);
+  return trimmed.length > 0 && trimmed.includes("/");
+}

--- a/src/components/AIConfigModal.tsx
+++ b/src/components/AIConfigModal.tsx
@@ -11,9 +11,15 @@ import {
 } from "react-native";
 import { testOpenRouterConnection } from "../ai/llm/llmAIClient";
 import { DEFAULT_LLM_CONFIG, LLMConfig } from "../ai/llm/llmConfig";
-import { AVAILABLE_MODELS as MODELS } from "../ai/llm/llmModels";
+import {
+  DEFAULT_MODEL,
+  DEFAULT_MODEL_ID,
+  DEFAULT_MODEL_SENTINEL,
+  isDefaultModelSelection,
+  isValidOpenRouterModelId,
+  resolveOpenRouterModelId,
+} from "../ai/llm/llmModels";
 import { useModalsTranslation } from "../hooks/useTranslation";
-import { ModalsTranslationKey } from "../locales/types";
 
 // ─── Props ───────────────────────────────────────────────────────────────────
 
@@ -42,19 +48,34 @@ const AIConfigModal: React.FC<AIConfigModalProps> = ({
 }) => {
   const { t } = useModalsTranslation();
   const [useLLM, setUseLLM] = useState(currentConfig.enabled);
-  const [selectedModel, setSelectedModel] = useState(
-    currentConfig.model || DEFAULT_LLM_CONFIG.model,
+  const [selectionMode, setSelectionMode] = useState<"default" | "custom">(
+    isDefaultModelSelection(currentConfig.model) ? "default" : "custom",
+  );
+  const [customModel, setCustomModel] = useState(
+    isDefaultModelSelection(currentConfig.model) ? "" : currentConfig.model,
   );
   const [apiKey, setApiKey] = useState(currentConfig.apiKey || "");
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>({
     kind: "idle",
   });
 
+  // The value persisted to config: sentinel for Default, custom id otherwise.
+  const storedModel =
+    selectionMode === "default" ? DEFAULT_MODEL_SENTINEL : customModel.trim();
+  // Concrete OpenRouter id used for the connectivity test (and at play time).
+  const resolvedModel = resolveOpenRouterModelId(storedModel);
+  // Display label for the Default card + success banner, e.g. "Default (Gemini 3.1 Flash Lite)".
+  const defaultModelLabel = t("aiConfig.llm.defaultModelName", {
+    modelName: DEFAULT_MODEL.displayName,
+  });
+
   // Sync local state when the modal opens (handles mid-game reopen)
   useEffect(() => {
     if (visible) {
+      const isDefault = isDefaultModelSelection(currentConfig.model);
       setUseLLM(currentConfig.enabled);
-      setSelectedModel(currentConfig.model || DEFAULT_LLM_CONFIG.model);
+      setSelectionMode(isDefault ? "default" : "custom");
+      setCustomModel(isDefault ? "" : currentConfig.model);
       setApiKey(currentConfig.apiKey || "");
       setConnectionStatus({ kind: "idle" });
     }
@@ -76,7 +97,7 @@ const AIConfigModal: React.FC<AIConfigModalProps> = ({
         ...DEFAULT_LLM_CONFIG,
         enabled: false,
         apiKey: apiKey.trim(),
-        model: selectedModel,
+        model: storedModel,
       });
       return;
     }
@@ -89,11 +110,20 @@ const AIConfigModal: React.FC<AIConfigModalProps> = ({
       return;
     }
 
+    // Validate custom model id before hitting the network.
+    if (selectionMode === "custom" && !isValidOpenRouterModelId(customModel)) {
+      setConnectionStatus({
+        kind: "error",
+        message: t("aiConfig.llm.customModelError"),
+      });
+      return;
+    }
+
     setConnectionStatus({ kind: "testing" });
 
     const result = await testOpenRouterConnection(
       apiKey.trim(),
-      selectedModel,
+      resolvedModel,
       DEFAULT_LLM_CONFIG.apiUrl,
     );
 
@@ -102,14 +132,16 @@ const AIConfigModal: React.FC<AIConfigModalProps> = ({
         kind: "success",
         message: t("aiConfig.llm.connectedMsg", {
           modelName:
-            MODELS.find((m) => m.id === selectedModel)?.name ?? selectedModel,
+            selectionMode === "default"
+              ? defaultModelLabel
+              : customModel.trim(),
         }),
       });
       onSave({
         ...DEFAULT_LLM_CONFIG,
         enabled: true,
         apiKey: apiKey.trim(),
-        model: selectedModel,
+        model: storedModel,
       });
     } else {
       setConnectionStatus({
@@ -119,7 +151,17 @@ const AIConfigModal: React.FC<AIConfigModalProps> = ({
         }),
       });
     }
-  }, [useLLM, apiKey, selectedModel, onSave, t]);
+  }, [
+    useLLM,
+    apiKey,
+    selectionMode,
+    customModel,
+    storedModel,
+    resolvedModel,
+    defaultModelLabel,
+    onSave,
+    t,
+  ]);
 
   // ── Render ─────────────────────────────────────────────────────────────────
 
@@ -259,85 +301,108 @@ const AIConfigModal: React.FC<AIConfigModalProps> = ({
                   {t("aiConfig.llm.apiKeyHint").split("openrouter.ai")[1] || ""}
                 </Text>
 
-                {/* Model cards */}
+                {/* Model selection: Default vs Custom */}
                 <Text style={styles.sectionLabel}>
                   {t("aiConfig.llm.selectModelLabel")}
                 </Text>
-                {(() => {
-                  const modelsTranslations = t(
-                    "aiConfig.models" as unknown as ModalsTranslationKey,
-                    {
-                      returnObjects: true,
-                    },
-                  ) as unknown as Record<
-                    string,
-                    { rank?: string; description?: string }
-                  >;
-                  return MODELS.map((model) => {
-                    const isSelected = selectedModel === model.id;
-                    const translatedRank =
-                      modelsTranslations?.[model.id]?.rank || model.rank;
-                    const translatedDesc =
-                      modelsTranslations?.[model.id]?.description ||
-                      model.description;
-                    return (
-                      <TouchableOpacity
-                        key={model.id}
-                        style={[
-                          styles.modelCard,
-                          isSelected && styles.modelCardSelected,
-                        ]}
-                        onPress={() => {
-                          setSelectedModel(model.id);
-                          setConnectionStatus({ kind: "idle" });
-                        }}
-                        activeOpacity={0.75}
+
+                {/* Default card */}
+                <TouchableOpacity
+                  style={[
+                    styles.modelCard,
+                    selectionMode === "default" && styles.modelCardSelected,
+                  ]}
+                  onPress={() => {
+                    setSelectionMode("default");
+                    setConnectionStatus({ kind: "idle" });
+                  }}
+                  activeOpacity={0.75}
+                >
+                  <View style={styles.modelCardHeader}>
+                    <Text style={styles.modelIcon}>✨</Text>
+                    <View style={styles.modelNameBlock}>
+                      <Text style={styles.modelName}>{defaultModelLabel}</Text>
+                      <View
+                        style={[styles.rankBadge, { borderColor: "#06B6D4" }]}
                       >
-                        <View style={styles.modelCardHeader}>
-                          <Text style={styles.modelIcon}>{model.icon}</Text>
-                          <View style={styles.modelNameBlock}>
-                            <Text style={styles.modelName}>{model.name}</Text>
-                            <View
-                              style={[
-                                styles.rankBadge,
-                                { borderColor: model.rankColor },
-                              ]}
-                            >
-                              <Text
-                                style={[
-                                  styles.rankBadgeText,
-                                  { color: model.rankColor },
-                                ]}
-                              >
-                                {translatedRank}
-                              </Text>
-                            </View>
-                          </View>
-                          {isSelected && (
-                            <View style={styles.selectedCheck}>
-                              <Text style={styles.selectedCheckText}>✓</Text>
-                            </View>
-                          )}
-                        </View>
-                        <Text style={styles.modelDescription}>
-                          {translatedDesc}
+                        <Text
+                          style={[styles.rankBadgeText, { color: "#06B6D4" }]}
+                        >
+                          {t("aiConfig.llm.defaultModelBadge")}
                         </Text>
-                        <View style={styles.pricingRow}>
-                          <Text style={styles.pricingLabel}>
-                            {model.inputPrice}
-                            <Text style={styles.pricingUnit}> in</Text>
-                          </Text>
-                          <Text style={styles.pricingDivider}>/</Text>
-                          <Text style={styles.pricingLabel}>
-                            {model.outputPrice}
-                            <Text style={styles.pricingUnit}> out</Text>
-                          </Text>
-                          <Text style={styles.pricingUnit}> per 1M tokens</Text>
-                        </View>
-                      </TouchableOpacity>
-                    );
-                  });
-                })()}
+                      </View>
+                    </View>
+                    {selectionMode === "default" && (
+                      <View style={styles.selectedCheck}>
+                        <Text style={styles.selectedCheckText}>✓</Text>
+                      </View>
+                    )}
+                  </View>
+                  <Text style={styles.modelDescription}>
+                    {t("aiConfig.llm.defaultModelDesc")}
+                  </Text>
+                  <View style={styles.pricingRow}>
+                    <Text style={styles.pricingLabel}>
+                      {DEFAULT_MODEL.inputPrice}
+                      <Text style={styles.pricingUnit}> in</Text>
+                    </Text>
+                    <Text style={styles.pricingDivider}>/</Text>
+                    <Text style={styles.pricingLabel}>
+                      {DEFAULT_MODEL.outputPrice}
+                      <Text style={styles.pricingUnit}> out</Text>
+                    </Text>
+                    <Text style={styles.pricingUnit}> per 1M tokens</Text>
+                  </View>
+                  <Text style={styles.modelIdMono}>{DEFAULT_MODEL_ID}</Text>
+                </TouchableOpacity>
+
+                {/* Custom card */}
+                <TouchableOpacity
+                  style={[
+                    styles.modelCard,
+                    selectionMode === "custom" && styles.modelCardSelected,
+                  ]}
+                  onPress={() => {
+                    setSelectionMode("custom");
+                    setConnectionStatus({ kind: "idle" });
+                  }}
+                  activeOpacity={0.75}
+                >
+                  <View style={styles.modelCardHeader}>
+                    <Text style={styles.modelIcon}>⚙️</Text>
+                    <View style={styles.modelNameBlock}>
+                      <Text style={styles.modelName}>
+                        {t("aiConfig.llm.customModelName")}
+                      </Text>
+                    </View>
+                    {selectionMode === "custom" && (
+                      <View style={styles.selectedCheck}>
+                        <Text style={styles.selectedCheckText}>✓</Text>
+                      </View>
+                    )}
+                  </View>
+                  <Text style={styles.modelDescription}>
+                    {t("aiConfig.llm.customModelDesc")}
+                  </Text>
+
+                  {selectionMode === "custom" && (
+                    <TextInput
+                      style={styles.customModelInput}
+                      value={customModel}
+                      onChangeText={(v) => {
+                        setCustomModel(v);
+                        if (connectionStatus.kind !== "idle") {
+                          setConnectionStatus({ kind: "idle" });
+                        }
+                      }}
+                      placeholder={t("aiConfig.llm.customModelPlaceholder")}
+                      placeholderTextColor="#9CA3AF"
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                      spellCheck={false}
+                    />
+                  )}
+                </TouchableOpacity>
               </View>
             )}
           </ScrollView>
@@ -642,6 +707,24 @@ const styles = StyleSheet.create({
   pricingLabel: { fontSize: 12, fontWeight: "700", color: "#CBD5E1" },
   pricingDivider: { fontSize: 12, color: "#475569" },
   pricingUnit: { fontSize: 11, color: "#64748B", fontWeight: "400" },
+  modelIdMono: {
+    fontSize: 11,
+    color: "#64748B",
+    fontFamily: "monospace",
+    marginTop: 6,
+  },
+  customModelInput: {
+    marginTop: 10,
+    backgroundColor: "#0F0F1A",
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 14,
+    color: "#F1F5F9",
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.1)",
+    fontFamily: "monospace",
+  },
 
   // (test button removed — merged into footer)
 

--- a/src/locales/en/modals.json
+++ b/src/locales/en/modals.json
@@ -54,30 +54,19 @@
       "selectModelLabel": "Select Model",
       "enterKeyError": "Please enter your OpenRouter API key first.",
       "connectedMsg": "✓ Connected — {{modelName}} is ready!",
-      "connectionError": "✗ {{error}}"
+      "connectionError": "✗ {{error}}",
+      "defaultModelName": "Default ({{modelName}})",
+      "defaultModelDesc": "Recommended. Speed champion (~1-2s latency) with improved strategic reasoning and outstanding rules compliance.",
+      "defaultModelBadge": "Recommended",
+      "customModelName": "Custom",
+      "customModelDesc": "Use any OpenRouter model by entering its model id (provider/model).",
+      "customModelPlaceholder": "e.g. deepseek/deepseek-chat",
+      "customModelError": "Enter a valid OpenRouter model id (e.g. deepseek/deepseek-chat)."
     },
     "buttons": {
       "cancel": "Cancel",
       "verifyAndSave": "Verify & Save",
       "save": "Save"
-    },
-    "models": {
-      "google/gemini-3.1-flash-lite": {
-        "rank": "Best Overall (Recommended)",
-        "description": "Recommended. Speed Champion (~1-2s latency). Optimized for low-latency, high-volume workloads with improved strategic reasoning and outstanding rules compliance."
-      },
-      "x-ai/grok-4.5": {
-        "rank": "Elite Strategy & Reasoning",
-        "description": "State-of-the-art strategic and reasoning model from xAI. Outstanding tactical depth and card coordination."
-      },
-      "deepseek/deepseek-v4-flash": {
-        "rank": "Peak Strategic Master",
-        "description": "Strategic master. High strategic depth and excellent rules compliance, though latency can vary under load."
-      },
-      "qwen/qwen3.6-flash": {
-        "rank": "Elite Strategy",
-        "description": "Elite tactical engine. Flawless rules compliance, superb combo recognition, and great point preservation."
-      }
     }
   }
 }

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -145,17 +145,18 @@ export interface ModalsTranslations {
       enterKeyError: string;
       connectedMsg: string;
       connectionError: string;
+      defaultModelName: string;
+      defaultModelDesc: string;
+      defaultModelBadge: string;
+      customModelName: string;
+      customModelDesc: string;
+      customModelPlaceholder: string;
+      customModelError: string;
     };
     buttons: {
       cancel: string;
       verifyAndSave: string;
       save: string;
-    };
-    models: {
-      [modelId: string]: {
-        rank: string;
-        description: string;
-      };
     };
   };
 }

--- a/src/locales/zh/modals.json
+++ b/src/locales/zh/modals.json
@@ -54,30 +54,19 @@
       "selectModelLabel": "选择模型",
       "enterKeyError": "请先输入您的 OpenRouter API 密钥。",
       "connectedMsg": "✓ 已连接 — {{modelName}} 已准备就绪！",
-      "connectionError": "✗ {{error}}"
+      "connectionError": "✗ {{error}}",
+      "defaultModelName": "默认 ({{modelName}})",
+      "defaultModelDesc": "推荐。速度极快（~1-2秒延迟），战略推理更优且规则遵循出色。",
+      "defaultModelBadge": "推荐",
+      "customModelName": "自定义",
+      "customModelDesc": "输入 OpenRouter 模型 id（格式：provider/model）以使用任意模型。",
+      "customModelPlaceholder": "例如 deepseek/deepseek-chat",
+      "customModelError": "请输入有效的 OpenRouter 模型 id（例如：deepseek/deepseek-chat）。"
     },
     "buttons": {
       "cancel": "取消",
       "verifyAndSave": "验证并保存",
       "save": "保存"
-    },
-    "models": {
-      "google/gemini-3.1-flash-lite": {
-        "rank": "综合最佳 (推荐)",
-        "description": "首选推荐。速度极快（~1-2秒延迟）。针对低延迟、高吞吐工作负载进行了优化，且提升了战略推理与规则遵循能力。"
-      },
-      "x-ai/grok-4.5": {
-        "rank": "精英策略与推理",
-        "description": "来自 xAI 的顶尖策略与推理模型。拥有杰出的战术深度和卡牌协作能力。"
-      },
-      "deepseek/deepseek-v4-flash": {
-        "rank": "策略之王",
-        "description": "战略大师。拥有极高的战略深度与出色的规则遵循能力，但在负载下可能存在延迟波动。"
-      },
-      "qwen/qwen3.6-flash": {
-        "rank": "精英策略",
-        "description": "精英战术引擎。完美的规则遵循，出色的牌组识别，以及绝佳的分数防守策略。"
-      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Replaces the curated 4-model catalog picker (`AVAILABLE_MODELS`) with a **Default** card + **Custom** free-text OpenRouter model id (`provider/model`). Removes the model allowlist and its per-model i18n/types surface from the shipping app.

- **Default card** — recommended built-in model, shown with name `Default (Gemini 3.1 Flash Lite)`, badge, description, pricing, and model id.
- **Custom card** — text input for any OpenRouter model id (placeholder `e.g. deepseek/deepseek-chat`), with pre-network shape validation.

## Design

- Persist the sentinel `"default"` for the Default selection; resolve to the concrete model id only at call/verify time via `resolveOpenRouterModelId`. This means the underlying default model can change later without migrating saved configs (configs saved under this code hold the sentinel, which always tracks the current default).
- `getLLMConfig` normalizes the sentinel + legacy concrete default id on load and preserves any free-form custom id (dropped the `AVAILABLE_MODELS` allowlist and the `NODE_ENV==="test"` hatch — both superseded).
- `llmAIStrategy` resolves `config.model` before the OpenRouter call, so the sentinel never reaches the API.
- Default-model metadata kept cohesive in one `DEFAULT_MODEL` object; model-id semantics (`resolveOpenRouterModelId` / `isDefaultModelSelection` / `isValidOpenRouterModelId`) centralized in `llmModels.ts`.

## Files
- `src/ai/llm/llmModels.ts` — sentinel + cohesive default model + helpers
- `src/ai/llm/llmConfig.ts` — sentinel default, normalize-on-load
- `src/ai/llm/llmAIStrategy.ts` — resolve before API call
- `src/components/AIConfigModal.tsx` — Default/Custom selector
- `src/locales/{en,zh}/modals.json` + `src/locales/types.ts` — new keys, removed `aiConfig.models`

## Test plan
- [x] `npm run qualitycheck` — typecheck, lint, 737 tests pass
- [ ] Fresh user: Default selected → Verify & Save → localStorage `model === "default"`
- [ ] Custom: enter `deepseek/deepseek-chat` → save persists that id → request uses it
- [ ] Validation: empty custom or no-slash id → error banner, no save
- [ ] zh locale: Default/Custom strings render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)