### PR TITLE
Refactor LLM prompts and rules for model neutrality

### DIFF
--- a/__tests__/ai/llmGamePrompt.test.ts
+++ b/__tests__/ai/llmGamePrompt.test.ts
@@ -217,7 +217,7 @@ describe("LLM prompt — facts & diagnosis, not rules", () => {
 
     expect(user).toContain("## Lead Options");
     expect(user).toContain(
-      "[A♠ A♠] (pair) → unbeatable in-suit → wins unless an opponent ruffs; keeps the lead (spends a boss, not trump)",
+      "[A♠ A♠] (pair) → unbeatable in-suit → wins unless ruffed; keeps the lead; spends this combo",
     );
     expect(user).not.toMatch(/Rule Score/);
     // System prompt keeps objective mechanics, drops prescriptive strategy.
@@ -248,11 +248,11 @@ describe("LLM prompt — facts & diagnosis, not rules", () => {
     );
     // Low trump pair: drain framing + cost (no "wins the lead" reward-word).
     expect(user).toContain(
-      "[7♥ 7♥] (trump pair) → opponents must follow with a trump pair; repeated trump-pair leads drain their trump and force out trump point cards you capture, but a higher trump pair beats this one; spends a trump pair",
+      "[7♥ 7♥] (trump pair) → opponents must follow with a trump pair if they hold it, and a higher trump pair beats this play; spends a trump pair",
     );
     // Trump-rank pair: flagged as scarce.
     expect(user).toContain(
-      "[2♠ 2♠] (trump pair) → opponents must follow with a trump pair; repeated trump-pair leads drain their trump and force out trump point cards you capture, but a higher trump pair beats this one; spends scarce high trump (jokers/trump-rank)",
+      "[2♠ 2♠] (trump pair) → opponents must follow with a trump pair if they hold it, and a higher trump pair beats this play; spends scarce high trump (jokers/trump-rank)",
     );
   });
 
@@ -334,10 +334,10 @@ describe("LLM prompt — facts & diagnosis, not rules", () => {
     const { user } = buildLLMUserPrompt(withHand, PlayerId.Bot1, hand);
 
     expect(user).toContain(
-      "BJ (trump) → no trump still out beats it, but opponents follow low so you win ≈no points",
+      "BJ (trump) → no higher trump is still out (unbeatable single trump); wins the trick; spends this trump",
     );
     expect(user).toContain(
-      "trump singles (A♥) → a higher trump is still out, so leading one likely loses — it passes the lead and gives up no points; spends a trump",
+      "trump singles (A♥) → at least one higher trump is still out (beatable single trump); passes the lead if a higher trump is played; spends this trump",
     );
   });
 
@@ -357,7 +357,7 @@ describe("LLM prompt — facts & diagnosis, not rules", () => {
     const { user } = buildLLMUserPrompt(withHand, PlayerId.Bot1, hand);
 
     expect(user).toContain(
-      "K♠ (Spades, 10 pts) → a higher Spades is still out — if an opponent takes it you feed them 10 pts",
+      "K♠ (Spades, 10 pts) → a higher Spades is still out; passes the lead if a higher card is played; spends this card",
     );
   });
 
@@ -389,7 +389,7 @@ describe("LLM prompt — facts & diagnosis, not rules", () => {
     const { user } = buildLLMUserPrompt(state, PlayerId.Bot3, hand);
 
     expect(user).toContain(
-      "A♠ → overtakes your teammate's already-safe win — spends A♠ for no gain",
+      "A♠ → overtakes your teammate's already-safe win; spends A♠",
     );
   });
 
@@ -418,7 +418,7 @@ describe("LLM prompt — facts & diagnosis, not rules", () => {
     const { user } = buildLLMUserPrompt(state, PlayerId.Bot2, hand);
 
     expect(user).toContain(
-      "A♠ → overtakes your teammate to shield the 10 pts from bot3; costs A♠",
+      "A♠ → overtakes your teammate's win (not yet safe from bot3); costs A♠",
     );
   });
 

--- a/src/ai/llm/llmPositionDiagnosis.ts
+++ b/src/ai/llm/llmPositionDiagnosis.ts
@@ -167,10 +167,8 @@ export function buildFollowingOptions(
     if (!isTeammateWinning)
       return `${winYield(trickPoints)}${pointCost(cards)}`;
     if (teammateWinSafe)
-      return `overtakes your teammate's already-safe win — spends ${playLabel(cards)} for no gain`;
-    return trickPoints > 0
-      ? `overtakes your teammate to shield the ${trickPoints} pts from ${oppList}; costs ${playLabel(cards)}`
-      : `overtakes your teammate to deny ${oppList} the trick; costs ${playLabel(cards)}`;
+      return `overtakes your teammate's already-safe win; spends ${playLabel(cards)}`;
+    return `overtakes your teammate's win (not yet safe from ${oppList}); costs ${playLabel(cards)}`;
   };
 
   // A non-winning card is not "trash" if it is the highest live card of its
@@ -382,7 +380,7 @@ function renderVoidOptions(a: VoidArgs): string[] {
     }
   } else if (!a.isTeammateWinning) {
     lines.push(
-      `- No trump you hold beats ${a.winnerId} — ruffing only spends trump for nothing.`,
+      `- No trump you hold beats ${a.winnerId}; playing a trump card here will not win the trick.`,
     );
   }
 
@@ -528,20 +526,19 @@ export function buildLeadingOptions(
     });
   };
 
-  // Off-suit, structured (multi-combo / tractor / pair) — highest leverage.
+  // Off-suit, structured (multi-combo / tractor / pair)
   const offStructured = offSuit.filter((c) => c.cards.length > 1);
   for (const c of offStructured) {
     const kind =
       c.type === ComboType.Invalid ? "multi-combo" : c.type.toLowerCase();
     const pts = c.metadata.points > 0 ? `, ${c.metadata.points} pts` : "";
     const fate = c.metadata.isUnbeatable
-      ? `unbeatable in-suit → wins unless an opponent ruffs; keeps the lead (spends a boss, not trump)${c.metadata.points > 0 ? ` — banks ${c.metadata.points} pts` : ""}`
-      : `a higher ${c.metadata.suit} combo or a ruff can beat it${c.metadata.points > 0 ? ` — if taken you feed ${c.metadata.points} pts` : ""}`;
+      ? `unbeatable in-suit → wins unless ruffed; keeps the lead; spends this combo`
+      : `beatable by a higher ${c.metadata.suit} combo or a ruff; spends this combo`;
     lines.push(`- ${playLabel(c.cards)} (${kind}${pts}) → ${fate}`);
   }
 
-  // Off-suit singles: bosses (likely win) and point cards stand alone; collapse
-  // the low rubbish per suit into one class.
+  // Off-suit singles
   const offSingles = dedupeSingles(offSuit.filter((c) => c.cards.length === 1));
   const notableSingles = offSingles.filter(
     (c) =>
@@ -553,25 +550,21 @@ export function buildLeadingOptions(
     const card = c.cards[0];
     const pts = card.points > 0 ? `, ${card.points} pts` : "";
     const fate = c.metadata.isUnbeatable
-      ? `unbeatable in-suit → wins unless an opponent ruffs; keeps the lead (spends a boss, not trump)${card.points > 0 ? ` — banks ${card.points} pts` : ""}`
+      ? `unbeatable in-suit → wins unless ruffed; keeps the lead; spends this card`
       : isBiggestInSuit(card, trumpInfo)
-        ? `suit boss → wins unless ruffed${card.points > 0 ? `; if ruffed you feed ${card.points} pts` : ""}`
-        : `a higher ${suitName(card.suit)} is still out — if an opponent takes it you feed them ${card.points} pts`;
+        ? `suit boss → wins unless ruffed; spends this card`
+        : `a higher ${suitName(card.suit)} is still out; passes the lead if a higher card is played; spends this card`;
     lines.push(`- ${card.toString()} (${suitName(card.suit)}${pts}) → ${fate}`);
   }
   const rubbishSingles = offSingles.filter((c) => !notableSingles.includes(c));
   if (rubbishSingles.length > 0) {
     const cards = rubbishSingles.map((c) => c.cards[0]);
     lines.push(
-      `- low singles (${listLabel(cards)}) → low cards; give up the lead, carry no points`,
+      `- low singles (${listLabel(cards)}) → beatable cards; pass the lead if a higher card is played; spend these cards`,
     );
   }
 
-  // Trump leads stated as point facts. A trump lead never wins points from
-  // opponents by force (they follow with their lowest), so: a high trump SINGLE
-  // wastes your scarcest card; strong trump PAIRS, led when you hold several,
-  // drain opponents' trump and force out their trump point cards; a low trump
-  // simply hands on the lead. The dominance line lets the LLM judge draining.
+  // Trump leads stated as point facts.
   if (trump.length > 0) {
     const heldTrumpPairs = countHeldPairs(
       hand.filter((c) => c.isTrump(trumpInfo)),
@@ -596,7 +589,7 @@ export function buildLeadingOptions(
         ? "spends scarce high trump (jokers/trump-rank)"
         : "spends a trump pair";
       lines.push(
-        `- ${playLabel(c.cards)} (trump ${kind}) → opponents must follow with a trump ${kind}; repeated trump-pair leads drain their trump and force out trump point cards you capture, but a higher trump ${kind} beats this one; ${cost}`,
+        `- ${playLabel(c.cards)} (trump ${kind}) → opponents must follow with a trump ${kind} if they hold it, and a higher trump ${kind} beats this play; ${cost}`,
       );
     }
 
@@ -604,9 +597,6 @@ export function buildLeadingOptions(
       trump.filter((c) => c.cards.length === 1),
     );
     if (trumpSingles.length > 0) {
-      // A trump single wins only if no higher trump is unseen in another hand —
-      // the engine does that accounting so the model does not mistake a high but
-      // beatable trump (e.g. SJ while a BJ is out) for "the strongest".
       const isBeaten = (card: Card): boolean =>
         unseenTrump.some((u) => compareCards(u, card, trumpInfo) > 0);
       const winners = trumpSingles.filter((c) => !isBeaten(c.cards[0]));
@@ -614,7 +604,7 @@ export function buildLeadingOptions(
 
       for (const c of sortCandidatesDesc(winners, trumpInfo)) {
         lines.push(
-          `- ${c.cards[0].toString()} (trump) → no trump still out beats it, but opponents follow low so you win ≈no points; spends your top trump (gone for ruffing or the final trick)`,
+          `- ${c.cards[0].toString()} (trump) → no higher trump is still out (unbeatable single trump); wins the trick; spends this trump`,
         );
       }
       if (beaten.length > 0) {
@@ -626,7 +616,7 @@ export function buildLeadingOptions(
               calculateCardStrategicValue(y, trumpInfo, "basic"),
           );
         lines.push(
-          `- trump singles (${listLabel(cards)}) → a higher trump is still out, so leading one likely loses — it passes the lead and gives up no points; spends a trump`,
+          `- trump singles (${listLabel(cards)}) → at least one higher trump is still out (beatable single trump); passes the lead if a higher trump is played; spends this trump`,
         );
       }
     }

--- a/src/ai/llm/llmPromptTemplates.ts
+++ b/src/ai/llm/llmPromptTemplates.ts
@@ -27,7 +27,7 @@ export const STATIC_LLM_GAME_RULES = `# Shengji / Tractor — Game Reference
 ## 5. Reading the Options & Strategy
 - **## Lead Options** / **## Your Options** list EVERY legal play and its point consequence. Choose only from those listed plays — freelancing cards by printed suit is how illegal follows happen.
 - Choose the play that is best for your team's point total this round. The engine has done the counting and the lookahead; the strategic judgement is yours.
-- **Resource Conservation**: High cards (Jokers, trump ranks, and off-suit bosses) are scarce winning assets. Wasting them on a trick you cannot win, or that your teammate has already secured, cedes future control. When playing a losing card, lean toward conserving your highest cards.
+- **Resource Conservation**: High cards (Jokers, trump ranks, and off-suit bosses) are scarce assets that win tricks and keep control. Playing them on a trick that you cannot win, or that your teammate has already won/secured, spends them without changing the trick winner.
 `;
 
 export interface UserPromptTemplateArgs {


### PR DESCRIPTION
Reviews all LLM prompts, rules, and dynamic options templates to ensure model neutrality and prevent decision hinting. All options now state objective facts.